### PR TITLE
API 응답 구조 통일 및 RESTful 엔드포인트 개선

### DIFF
--- a/src/main/java/com/pawpawlog/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/pawpawlog/global/exception/GlobalExceptionHandler.java
@@ -23,7 +23,10 @@ public class GlobalExceptionHandler {
 
     return ResponseEntity
         .status(errorCode.getStatus())
-        .body(ApiResponse.error(errorCode.getMessage()));
+        .body(ApiResponse.error(
+            errorCode.name(),
+            errorCode.getMessage()
+        ));
   }
 
   @ExceptionHandler(MethodArgumentNotValidException.class)
@@ -48,7 +51,11 @@ public class GlobalExceptionHandler {
 
     return ResponseEntity
         .status(errorCode.getStatus())
-        .body(ApiResponse.error(errorCode.getMessage(), errors));
+        .body(ApiResponse.error(
+            errorCode.name(),
+            errorCode.getMessage(),
+            errors
+        ));
   }
 
   @ExceptionHandler(Exception.class)
@@ -60,6 +67,9 @@ public class GlobalExceptionHandler {
 
     return ResponseEntity
         .status(errorCode.getStatus())
-        .body(ApiResponse.error(errorCode.getMessage()));
+        .body(ApiResponse.error(
+            errorCode.name(),
+            errorCode.getMessage()
+        ));
   }
 }

--- a/src/main/java/com/pawpawlog/global/response/ApiResponse.java
+++ b/src/main/java/com/pawpawlog/global/response/ApiResponse.java
@@ -1,40 +1,39 @@
 package com.pawpawlog.global.response;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
-import lombok.AllArgsConstructor;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import lombok.Getter;
 
 @Getter
-@AllArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonPropertyOrder({"success", "code", "message", "data"})
 public class ApiResponse<T> {
 
   private final boolean success;
+  private final String code;
   private final String message;
-
-  @JsonInclude(JsonInclude.Include.NON_NULL)
   private final T data;
 
-  public static ApiResponse<Void> ok() {
-    return new ApiResponse<>(true, "요청이 성공적으로 처리되었습니다.", null);
+  private ApiResponse(boolean success, String code, String message, T data) {
+    this.success = success;
+    this.code = code;
+    this.message = message;
+    this.data = data;
   }
 
-  public static <T> ApiResponse<T> ok(T data) {
-    return new ApiResponse<>(true, "요청이 성공적으로 처리되었습니다.", data);
+  public static <T> ApiResponse<T> success(T data) {
+    return new ApiResponse<>(true, null, null, data);
   }
 
-  public static ApiResponse<Void> ok(String message) {
-    return new ApiResponse<>(true, message, null);
+  public static ApiResponse<Void> success() {
+    return new ApiResponse<>(true, null, null, null);
   }
 
-  public static <T> ApiResponse<T> ok(String message, T data) {
-    return new ApiResponse<>(true, message, data);
+  public static ApiResponse<Void> error(String code, String message) {
+    return new ApiResponse<>(false, code, message, null);
   }
 
-  public static ApiResponse<Void> error(String message) {
-    return new ApiResponse<>(false, message, null);
-  }
-
-  public static <T> ApiResponse<T> error(String message, T data) {
-    return new ApiResponse<>(false, message, data);
+  public static <T> ApiResponse<T> error(String code, String message, T data) {
+    return new ApiResponse<>(false, code, message, data);
   }
 }

--- a/src/main/java/com/pawpawlog/user/controller/UserController.java
+++ b/src/main/java/com/pawpawlog/user/controller/UserController.java
@@ -9,10 +9,10 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -22,22 +22,16 @@ public class UserController {
 
   private final UserService userService;
 
-  @GetMapping("/verify-username")
-  public ResponseEntity<ApiResponse<Void>> verifyUsername(
-      @RequestParam String username) {
-
-    userService.verifyUsername(username);
-    return ResponseEntity.ok(ApiResponse.ok("사용 가능한 아이디입니다."));
+  @GetMapping("/usernames/{username}/exists")
+  public ResponseEntity<ApiResponse<Boolean>> checkUsernameExists(@PathVariable String username) {
+    boolean exists = userService.existsByUsername(username);
+    return ResponseEntity.ok(ApiResponse.success(exists));
   }
 
   @PostMapping("/signup")
   public ResponseEntity<ApiResponse<UserResponse>> signUp(
       @RequestBody @Valid SignUpRequest request) {
-
     UserResponse response = userService.signUp(request);
-
-    return ResponseEntity
-        .status(HttpStatus.CREATED)
-        .body(ApiResponse.ok("회원가입이 완료되었습니다.", response));
+    return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success(response));
   }
 }

--- a/src/main/java/com/pawpawlog/user/repository/UserRepository.java
+++ b/src/main/java/com/pawpawlog/user/repository/UserRepository.java
@@ -1,7 +1,6 @@
 package com.pawpawlog.user.repository;
 
 import com.pawpawlog.user.entity.User;
-import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface UserRepository extends JpaRepository<User, Long> {
@@ -9,6 +8,4 @@ public interface UserRepository extends JpaRepository<User, Long> {
   boolean existsByUsername(String username);
 
   boolean existsByNicknameAndTag(String nickname, String tag);
-
-  Optional<User> findByUsername(String username);
 }

--- a/src/main/java/com/pawpawlog/user/service/UserService.java
+++ b/src/main/java/com/pawpawlog/user/service/UserService.java
@@ -23,10 +23,8 @@ public class UserService {
   private final UserRepository userRepository;
   private final PasswordEncoder passwordEncoder;
 
-  public void verifyUsername(String username) {
-    if (userRepository.existsByUsername(username)) {
-      throw new CustomException(ErrorCode.DUPLICATE_USERNAME);
-    }
+  public boolean existsByUsername(String username) {
+    return userRepository.existsByUsername(username);
   }
 
   @Transactional


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- #3

## 📝 작업 내용

- 공통 응답 구조 통일 (`success / code / message / data`)
- 회원가입 엔드포인트 REST 컨벤션에 맞게 수정 (`POST /users`)