### PR TITLE
네이버 OAuth2 소셜 로그인 구현

### DIFF
--- a/src/main/java/com/pawpawlog/auth/oauth2/CustomOAuth2UserService.java
+++ b/src/main/java/com/pawpawlog/auth/oauth2/CustomOAuth2UserService.java
@@ -1,6 +1,7 @@
 package com.pawpawlog.auth.oauth2;
 
 import com.pawpawlog.auth.oauth2.userinfo.KakaoOAuth2UserInfo;
+import com.pawpawlog.auth.oauth2.userinfo.NaverOAuth2UserInfo;
 import com.pawpawlog.auth.oauth2.userinfo.OAuth2UserInfo;
 import com.pawpawlog.user.entity.User;
 import com.pawpawlog.user.service.UserService;
@@ -38,6 +39,7 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
   private OAuth2UserInfo resolveUserInfo(String registrationId, Map<String, Object> attributes) {
     return switch (registrationId) {
       case "kakao" -> new KakaoOAuth2UserInfo(attributes);
+      case "naver" -> new NaverOAuth2UserInfo(attributes);
       default -> throw new OAuth2AuthenticationException(
           new OAuth2Error(
               "unsupported_provider",
@@ -59,7 +61,7 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
     log.debug("신규 OAuth2 유저 생성 - provider: {}, providerId: {}",
         userInfo.getProvider(), userInfo.getProviderId());
     return userService.registerOAuth2User(
-        userInfo.getNickname(),
+        userInfo.getNicknameOrDefault(),
         userInfo.getProvider(),
         userInfo.getProviderId(),
         userInfo.getProfileImageUrl()

--- a/src/main/java/com/pawpawlog/auth/oauth2/userinfo/KakaoOAuth2UserInfo.java
+++ b/src/main/java/com/pawpawlog/auth/oauth2/userinfo/KakaoOAuth2UserInfo.java
@@ -30,7 +30,7 @@ public class KakaoOAuth2UserInfo implements OAuth2UserInfo {
 
   @Override
   public String getNickname() {
-    return (String) profile.getOrDefault("nickname", "사용자");
+    return (String) profile.get("nickname");
   }
 
   @Override

--- a/src/main/java/com/pawpawlog/auth/oauth2/userinfo/NaverOAuth2UserInfo.java
+++ b/src/main/java/com/pawpawlog/auth/oauth2/userinfo/NaverOAuth2UserInfo.java
@@ -1,0 +1,34 @@
+package com.pawpawlog.auth.oauth2.userinfo;
+
+import com.pawpawlog.user.entity.Provider;
+import java.util.Map;
+
+public class NaverOAuth2UserInfo implements OAuth2UserInfo {
+
+  private final Map<String, Object> response;
+
+  @SuppressWarnings("unchecked")
+  public NaverOAuth2UserInfo(Map<String, Object> attributes) {
+    this.response = (Map<String, Object>) attributes.get("response");
+  }
+
+  @Override
+  public Provider getProvider() {
+    return Provider.NAVER;
+  }
+
+  @Override
+  public String getProviderId() {
+    return (String) response.get("id");
+  }
+
+  @Override
+  public String getNickname() {
+    return (String) response.get("nickname");
+  }
+
+  @Override
+  public String getProfileImageUrl() {
+    return (String) response.get("profile_image");
+  }
+}

--- a/src/main/java/com/pawpawlog/auth/oauth2/userinfo/OAuth2UserInfo.java
+++ b/src/main/java/com/pawpawlog/auth/oauth2/userinfo/OAuth2UserInfo.java
@@ -10,5 +10,10 @@ public interface OAuth2UserInfo {
 
   String getNickname();
 
+  default String getNicknameOrDefault() {
+    String nickname = getNickname();
+    return (nickname != null && !nickname.isBlank()) ? nickname : "사용자";
+  }
+
   String getProfileImageUrl();
 }

--- a/src/main/java/com/pawpawlog/auth/service/AuthService.java
+++ b/src/main/java/com/pawpawlog/auth/service/AuthService.java
@@ -30,7 +30,7 @@ public class AuthService {
   }
 
   public TokenResponse issueTokenForUser(String userId) {
-    JwtToken tokenPair = jwtTokenProvider.reissueToken(userId);
+    JwtToken tokenPair = jwtTokenProvider.generateTokenForUserId(userId);
     redisDao.saveRefreshToken(userId, tokenPair.refreshToken(), refreshExpiration);
     return TokenResponse.from(tokenPair);
   }
@@ -47,7 +47,7 @@ public class AuthService {
     }
 
     redisDao.deleteRefreshToken(id);
-    JwtToken tokenPair = jwtTokenProvider.reissueToken(id);
+    JwtToken tokenPair = jwtTokenProvider.generateTokenForUserId(id);
     redisDao.saveRefreshToken(id, tokenPair.refreshToken(), refreshExpiration);
     return TokenResponse.from(tokenPair);
   }

--- a/src/main/java/com/pawpawlog/global/config/SecurityConfig.java
+++ b/src/main/java/com/pawpawlog/global/config/SecurityConfig.java
@@ -73,9 +73,11 @@ public class SecurityConfig {
             session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
         .authorizeHttpRequests(auth ->
             auth
-                .requestMatchers(HttpMethod.POST, "/auth/login", "/auth/reissue", "/auth/logout", "/users").permitAll()
+                .requestMatchers(HttpMethod.POST, "/auth/login", "/auth/reissue", "/auth/logout",
+                    "/users").permitAll()
                 .requestMatchers(HttpMethod.GET, "/users/usernames/*", "/health").permitAll()
-                .requestMatchers("/swagger-ui/**", "/v3/api-docs/**", "/oauth2/**", "/login/oauth2/**").permitAll()
+                .requestMatchers("/swagger-ui/**", "/v3/api-docs/**", "/oauth2/**",
+                    "/login/oauth2/**").permitAll()
                 .anyRequest().authenticated())
         .exceptionHandling(exception -> exception
             .authenticationEntryPoint(authenticationEntryPoint)

--- a/src/main/java/com/pawpawlog/global/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/pawpawlog/global/jwt/JwtTokenProvider.java
@@ -59,7 +59,7 @@ public class JwtTokenProvider {
     return createTokenPair(id, authorities);
   }
 
-  public JwtToken reissueToken(String id) {
+  public JwtToken generateTokenForUserId(String id) {
     UserDetails userDetails = userDetailsService.loadUserByUsername(id);
     String authorities = extractAuthorities(userDetails.getAuthorities());
     return createTokenPair(id, authorities);

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -37,12 +37,27 @@ spring:
               - profile_nickname
               - profile_image
             client-name: Kakao
+          naver:
+            client-id: ${NAVER_CLIENT_ID}
+            client-secret: ${NAVER_CLIENT_SECRET}
+            redirect-uri: "{baseUrl}/login/oauth2/code/naver"
+            authorization-grant-type: authorization_code
+            client-authentication-method: client_secret_basic
+            scope:
+              - nickname
+              - profile_image
+            client-name: Naver
         provider:
           kakao:
             authorization-uri: https://kauth.kakao.com/oauth/authorize
             token-uri: https://kauth.kakao.com/oauth/token
             user-info-uri: https://kapi.kakao.com/v2/user/me
             user-name-attribute: id
+          naver:
+            authorization-uri: https://nid.naver.com/oauth2.0/authorize
+            token-uri: https://nid.naver.com/oauth2.0/token
+            user-info-uri: https://openapi.naver.com/v1/nid/me
+            user-name-attribute: response
 
 jwt:
   secret: ${JWT_SECRET}


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- #11

## 📝 작업 내용

- NaverOAuth2UserInfo 구현: 네이버 응답 데이터(response) 필드 매핑 및 파싱
- CustomOAuth2UserService: resolveUserInfo() switch에 naver 분기 추가
- application.yml: 네이버 OAuth2 클라이언트 등록 및 프로바이더 설정 추가
- 환경변수 추가: NAVER_CLIENT_ID, NAVER_CLIENT_SECRET
- reissueToken()을 generateTokenForUserId()로 메서드명 변경 (최초 발급 / 재발급 모두 사용되는 메서드로 의미에 맞게 수정)