### PR TITLE
닉네임 태그 구조 제거

### DIFF
--- a/src/main/java/com/pawpawlog/global/exception/ErrorCode.java
+++ b/src/main/java/com/pawpawlog/global/exception/ErrorCode.java
@@ -10,8 +10,6 @@ public enum ErrorCode {
   // User
   DUPLICATE_USERNAME(HttpStatus.CONFLICT, "이미 사용 중인 아이디입니다."),
   USER_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 유저입니다."),
-  INVALID_PASSWORD(HttpStatus.UNAUTHORIZED, "비밀번호가 일치하지 않습니다."),
-  TAG_GENERATION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "태그 생성에 실패했습니다."),
 
   // Auth
   UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "로그인이 필요합니다."),

--- a/src/main/java/com/pawpawlog/user/dto/response/UserResponse.java
+++ b/src/main/java/com/pawpawlog/user/dto/response/UserResponse.java
@@ -8,7 +8,6 @@ public record UserResponse(
     Long id,
     String username,
     String nickname,
-    String tag,
     String profileImageUrl
 ) {
 
@@ -17,7 +16,6 @@ public record UserResponse(
         user.getId(),
         user.getUsername(),
         user.getNickname(),
-        user.getTag(),
         user.getProfileImageUrl()
     );
   }

--- a/src/main/java/com/pawpawlog/user/entity/User.java
+++ b/src/main/java/com/pawpawlog/user/entity/User.java
@@ -24,7 +24,6 @@ import lombok.NoArgsConstructor;
 @Table(
     name = "users",
     uniqueConstraints = {
-        @UniqueConstraint(columnNames = {"nickname", "tag"}),
         @UniqueConstraint(columnNames = {"provider", "provider_id"})
     }
 )
@@ -46,9 +45,6 @@ public class User extends BaseEntity {
 
   @Column(nullable = false, length = 30)
   private String nickname;
-
-  @Column(nullable = false, length = 4)
-  private String tag;
 
   @Enumerated(EnumType.STRING)
   @Column(length = 10)

--- a/src/main/java/com/pawpawlog/user/repository/UserRepository.java
+++ b/src/main/java/com/pawpawlog/user/repository/UserRepository.java
@@ -11,7 +11,5 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
   boolean existsByUsername(String username);
 
-  boolean existsByNicknameAndTag(String nickname, String tag);
-
   Optional<User> findByProviderAndProviderId(Provider provider, String providerId);
 }

--- a/src/main/java/com/pawpawlog/user/service/UserService.java
+++ b/src/main/java/com/pawpawlog/user/service/UserService.java
@@ -8,7 +8,6 @@ import com.pawpawlog.user.entity.Provider;
 import com.pawpawlog.user.entity.User;
 import com.pawpawlog.user.repository.UserRepository;
 import java.util.Optional;
-import java.util.concurrent.ThreadLocalRandom;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
@@ -18,9 +17,6 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class UserService {
-
-  private static final int TAG_MAX_ATTEMPTS = 100;
-  private static final int TAG_RANGE = 10000;
 
   private final UserRepository userRepository;
   private final PasswordEncoder passwordEncoder;
@@ -39,13 +35,10 @@ public class UserService {
       throw new CustomException(ErrorCode.DUPLICATE_USERNAME);
     }
 
-    String tag = generateUniqueTag(request.nickname());
-
     User user = User.builder()
         .username(request.username())
         .password(passwordEncoder.encode(request.password()))
         .nickname(request.nickname())
-        .tag(tag)
         .build();
 
     return UserResponse.from(userRepository.save(user));
@@ -54,25 +47,11 @@ public class UserService {
   @Transactional
   public User registerOAuth2User(String nickname, Provider provider, String providerId,
       String profileImageUrl) {
-    String tag = generateUniqueTag(nickname);
     return userRepository.save(User.builder()
         .nickname(nickname)
-        .tag(tag)
         .provider(provider)
         .providerId(providerId)
         .profileImageUrl(profileImageUrl)
         .build());
-  }
-
-  private String generateUniqueTag(String nickname) {
-    for (int i = 0; i < TAG_MAX_ATTEMPTS; i++) {
-      String tag = String.format("%04d",
-          ThreadLocalRandom.current().nextInt(TAG_RANGE));
-
-      if (!userRepository.existsByNicknameAndTag(nickname, tag)) {
-        return tag;
-      }
-    }
-    throw new CustomException(ErrorCode.TAG_GENERATION_FAILED);
   }
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- #13 

## 📝 작업 내용

- User 엔티티에서 tag 필드 및 unique 제약 제거
- UserRepository에서 existsByNicknameAndTag() 제거
- UserService에서 generateUniqueTag() 및 태그 생성 로직 제거 (signUp, registerOAuth2User 포함)
- UserResponse에서 tag 필드 제거
- 미사용 ErrorCode.INVALID_PASSWORD 제거