### PR TITLE
User / Pet 순환 FK 제거 및 is_current 도입

### DIFF
--- a/src/main/java/com/pawpawlog/pet/entity/Pet.java
+++ b/src/main/java/com/pawpawlog/pet/entity/Pet.java
@@ -45,11 +45,23 @@ public class Pet extends BaseEntity {
 
   private LocalDate birthDate;
 
+  @Column(nullable = false)
+  @Builder.Default
+  private boolean isCurrent = false;
+
   public void updateName(String name) {
     this.name = name;
   }
 
   public void updateBirthDate(LocalDate birthDate) {
     this.birthDate = birthDate;
+  }
+
+  public void designateAsCurrent() {
+    this.isCurrent = true;
+  }
+
+  public void undesignateAsCurrent() {
+    this.isCurrent = false;
   }
 }

--- a/src/main/java/com/pawpawlog/pet/entity/Pet.java
+++ b/src/main/java/com/pawpawlog/pet/entity/Pet.java
@@ -57,11 +57,7 @@ public class Pet extends BaseEntity {
     this.birthDate = birthDate;
   }
 
-  public void designateAsCurrent() {
-    this.isCurrent = true;
-  }
-
-  public void undesignateAsCurrent() {
-    this.isCurrent = false;
+  public void setCurrent(boolean isCurrent) {
+    this.isCurrent = isCurrent;
   }
 }

--- a/src/main/java/com/pawpawlog/user/entity/User.java
+++ b/src/main/java/com/pawpawlog/user/entity/User.java
@@ -1,17 +1,13 @@
 package com.pawpawlog.user.entity;
 
 import com.pawpawlog.global.domain.BaseEntity;
-import com.pawpawlog.pet.entity.Pet;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
-import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import jakarta.persistence.UniqueConstraint;
 import lombok.AccessLevel;
@@ -66,10 +62,6 @@ public class User extends BaseEntity {
   @Builder.Default
   private UserRole role = UserRole.USER;
 
-  @ManyToOne(fetch = FetchType.LAZY)
-  @JoinColumn(name = "current_pet_id")
-  private Pet currentPet;
-
   public void suspend() {
     this.status = UserStatus.SUSPENDED;
   }
@@ -88,10 +80,6 @@ public class User extends BaseEntity {
 
   public void updateProfileImage(String profileImageUrl) {
     this.profileImageUrl = profileImageUrl;
-  }
-
-  public void updateCurrentPet(Pet pet) {
-    this.currentPet = pet;
   }
 
   // equals & hashCode


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- #14 

## 📝 작업 내용

- User 엔티티에서 currentPet 필드 및 updateCurrentPet() 제거                                                                                       
- Pet 엔티티에 isCurrent 필드 추가 (기본값 false)
- Pet에 setCurrent(boolean) 메서드 추가
- DB 마이그레이션: users.current_pet_id 컬럼 제거, pets.is_current 컬럼 추가