### PR TITLE
Swagger 문서화 설정 추가 및 prod 환경 비활성화

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,6 +25,7 @@ repositories {
 }
 
 dependencies {
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.9'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-security'

--- a/src/main/java/com/pawpawlog/auth/controller/AuthController.java
+++ b/src/main/java/com/pawpawlog/auth/controller/AuthController.java
@@ -4,6 +4,14 @@ import com.pawpawlog.auth.dto.response.TokenResponse;
 import com.pawpawlog.auth.service.AuthService;
 import com.pawpawlog.global.exception.CustomException;
 import com.pawpawlog.global.exception.ErrorCode;
+import com.pawpawlog.global.response.ErrorResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.util.StringUtils;
@@ -12,6 +20,7 @@ import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+@Tag(name = "Auth", description = "인증 관련 API")
 @RestController
 @RequestMapping("/auth")
 @RequiredArgsConstructor
@@ -21,12 +30,30 @@ public class AuthController {
 
   private final AuthService authService;
 
+  @SecurityRequirement(name = "BearerAuth")
+  @Operation(summary = "토큰 재발급", description = "리프레시 토큰으로 액세스 / 리프레시 토큰을 재발급합니다.")
+  @ApiResponses({
+      @ApiResponse(responseCode = "200", description = "재발급 성공",
+          content = @Content(mediaType = "application/json",
+              schema = @Schema(implementation = TokenResponse.class))),
+      @ApiResponse(responseCode = "401", description = "토큰 없음 / 유효하지 않은 토큰 / 만료된 토큰",
+          content = @Content(mediaType = "application/json",
+              schema = @Schema(implementation = ErrorResponse.class)))
+  })
   @PostMapping("/reissue")
   public ResponseEntity<TokenResponse> reissue(
       @RequestHeader(value = "Authorization", required = false) String bearerToken) {
     return ResponseEntity.ok(authService.reissue(extractToken(bearerToken)));
   }
 
+  @SecurityRequirement(name = "BearerAuth")
+  @Operation(summary = "로그아웃", description = "액세스 토큰을 블랙리스트에 등록하고 로그아웃합니다.")
+  @ApiResponses({
+      @ApiResponse(responseCode = "204", description = "로그아웃 성공", content = @Content),
+      @ApiResponse(responseCode = "401", description = "토큰 없음 / 유효하지 않은 토큰",
+          content = @Content(mediaType = "application/json",
+              schema = @Schema(implementation = ErrorResponse.class)))
+  })
   @PostMapping("/logout")
   public ResponseEntity<Void> logout(
       @RequestHeader(value = "Authorization", required = false) String bearerToken) {

--- a/src/main/java/com/pawpawlog/auth/dto/request/LoginRequest.java
+++ b/src/main/java/com/pawpawlog/auth/dto/request/LoginRequest.java
@@ -1,5 +1,10 @@
 package com.pawpawlog.auth.dto.request;
 
-public record LoginRequest(String username, String password) {
+import io.swagger.v3.oas.annotations.media.Schema;
 
-}
+public record LoginRequest(
+    @Schema(description = "아이디") String username,
+    @Schema(description = "비밀번호") String password
+) {
+
+}

--- a/src/main/java/com/pawpawlog/auth/dto/response/TokenResponse.java
+++ b/src/main/java/com/pawpawlog/auth/dto/response/TokenResponse.java
@@ -1,8 +1,12 @@
 package com.pawpawlog.auth.dto.response;
 
 import com.pawpawlog.global.jwt.JwtToken;
+import io.swagger.v3.oas.annotations.media.Schema;
 
-public record TokenResponse(String accessToken, String refreshToken) {
+public record TokenResponse(
+    @Schema(description = "액세스 토큰") String accessToken,
+    @Schema(description = "리프레시 토큰") String refreshToken
+) {
 
   public static TokenResponse from(JwtToken jwtToken) {
     return new TokenResponse(jwtToken.accessToken(), jwtToken.refreshToken());

--- a/src/main/java/com/pawpawlog/auth/service/AuthService.java
+++ b/src/main/java/com/pawpawlog/auth/service/AuthService.java
@@ -18,14 +18,14 @@ public class AuthService {
 
   @Value("${jwt.refresh-expiration}")
   private long refreshExpiration;
-
   private final JwtTokenProvider jwtTokenProvider;
   private final RedisDao redisDao;
 
   public TokenResponse issueTokenForAuth(Authentication authentication) {
     JwtToken tokenPair = jwtTokenProvider.generateToken(authentication);
     CustomUserDetails userDetails = (CustomUserDetails) authentication.getPrincipal();
-    redisDao.saveRefreshToken(String.valueOf(userDetails.getUserId()), tokenPair.refreshToken(), refreshExpiration);
+    redisDao.saveRefreshToken(String.valueOf(userDetails.getUserId()), tokenPair.refreshToken(),
+        refreshExpiration);
     return TokenResponse.from(tokenPair);
   }
 

--- a/src/main/java/com/pawpawlog/global/config/SwaggerConfig.java
+++ b/src/main/java/com/pawpawlog/global/config/SwaggerConfig.java
@@ -1,0 +1,71 @@
+package com.pawpawlog.global.config;
+
+import com.pawpawlog.auth.dto.request.LoginRequest;
+import com.pawpawlog.auth.dto.response.TokenResponse;
+import com.pawpawlog.global.response.ErrorResponse;
+import io.swagger.v3.core.converter.ModelConverters;
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.Operation;
+import io.swagger.v3.oas.models.PathItem;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.media.Content;
+import io.swagger.v3.oas.models.media.MediaType;
+import io.swagger.v3.oas.models.media.Schema;
+import io.swagger.v3.oas.models.parameters.RequestBody;
+import io.swagger.v3.oas.models.responses.ApiResponse;
+import io.swagger.v3.oas.models.responses.ApiResponses;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import java.util.List;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SwaggerConfig {
+
+  @Bean
+  public OpenAPI openAPI() {
+    Components components = new Components()
+        .addSecuritySchemes("BearerAuth", new SecurityScheme()
+            .type(SecurityScheme.Type.HTTP)
+            .scheme("bearer")
+            .bearerFormat("JWT")
+            .in(SecurityScheme.In.HEADER)
+            .name("Authorization"));
+
+    ModelConverters.getInstance().read(LoginRequest.class)
+        .forEach(components::addSchemas);
+    ModelConverters.getInstance().read(TokenResponse.class)
+        .forEach(components::addSchemas);
+    ModelConverters.getInstance().read(ErrorResponse.class)
+        .forEach(components::addSchemas);
+
+    return new OpenAPI()
+        .info(new Info()
+            .title("PawPawLog API")
+            .description("포포로그 API 명세서")
+            .version("v1.0.0"))
+        .components(components)
+        .path("/auth/login", loginPathItem());
+  }
+
+  private PathItem loginPathItem() {
+    return new PathItem().post(new Operation()
+        .tags(List.of("Auth"))
+        .summary("로그인")
+        .description("username / password로 로그인하여 JWT 토큰을 발급받습니다.")
+        .requestBody(new RequestBody()
+            .required(true)
+            .content(new Content().addMediaType("application/json",
+                new MediaType().schema(new Schema<>().$ref("#/components/schemas/LoginRequest")))))
+        .responses(new ApiResponses()
+            .addApiResponse("200", new ApiResponse()
+                .description("로그인 성공")
+                .content(new Content().addMediaType("application/json",
+                    new MediaType().schema(new Schema<>().$ref("#/components/schemas/TokenResponse")))))
+            .addApiResponse("401", new ApiResponse()
+                .description("아이디 또는 비밀번호 불일치")
+                .content(new Content().addMediaType("application/json",
+                    new MediaType().schema(new Schema<>().$ref("#/components/schemas/ErrorResponse")))))));
+  }
+}

--- a/src/main/java/com/pawpawlog/global/health/controller/HealthController.java
+++ b/src/main/java/com/pawpawlog/global/health/controller/HealthController.java
@@ -1,9 +1,11 @@
 package com.pawpawlog.global.health.controller;
 
+import io.swagger.v3.oas.annotations.Hidden;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+@Hidden
 @RestController
 public class HealthController {
 

--- a/src/main/java/com/pawpawlog/global/response/ErrorResponse.java
+++ b/src/main/java/com/pawpawlog/global/response/ErrorResponse.java
@@ -1,14 +1,20 @@
 package com.pawpawlog.global.response;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 
 @Getter
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class ErrorResponse {
 
+  @Schema(description = "에러 코드")
   private final String code;
+
+  @Schema(description = "에러 메시지")
   private final String message;
+
+  @Schema(description = "추가 데이터 (유효성 오류 시 필드별 메시지 포함)")
   private final Object data;
 
   private ErrorResponse(String code, String message, Object data) {

--- a/src/main/java/com/pawpawlog/user/controller/UserController.java
+++ b/src/main/java/com/pawpawlog/user/controller/UserController.java
@@ -1,9 +1,16 @@
 package com.pawpawlog.user.controller;
 
+import com.pawpawlog.global.response.ErrorResponse;
 import com.pawpawlog.user.dto.request.SignUpRequest;
-import com.pawpawlog.user.dto.response.UsernameAvailabilityResponse;
 import com.pawpawlog.user.dto.response.UserResponse;
+import com.pawpawlog.user.dto.response.UsernameAvailabilityResponse;
 import com.pawpawlog.user.service.UserService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -15,6 +22,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+@Tag(name = "User", description = "사용자 관련 API")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/users")
@@ -22,12 +30,21 @@ public class UserController {
 
   private final UserService userService;
 
+  @Operation(summary = "아이디 사용 가능 여부 확인", description = "해당 아이디가 이미 사용 중인지 확인합니다.")
+  @ApiResponses({
+      @ApiResponse(responseCode = "200", description = "확인 성공", content = @Content(mediaType = "application/json", schema = @Schema(implementation = UsernameAvailabilityResponse.class)))})
   @GetMapping("/usernames/{username}")
   public ResponseEntity<UsernameAvailabilityResponse> checkUsernameAvailability(
       @PathVariable String username) {
-    return ResponseEntity.ok(UsernameAvailabilityResponse.from(userService.existsByUsername(username)));
+    return ResponseEntity.ok(
+        UsernameAvailabilityResponse.from(userService.existsByUsername(username)));
   }
 
+  @Operation(summary = "회원가입", description = "username / password / nickname으로 신규 계정을 생성합니다.")
+  @ApiResponses({
+      @ApiResponse(responseCode = "201", description = "회원가입 성공", content = @Content(mediaType = "application/json", schema = @Schema(implementation = UserResponse.class))),
+      @ApiResponse(responseCode = "400", description = "입력값 유효성 오류", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))),
+      @ApiResponse(responseCode = "409", description = "아이디 중복", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class)))})
   @PostMapping
   public ResponseEntity<UserResponse> signUp(@RequestBody @Valid SignUpRequest request) {
     return ResponseEntity.status(HttpStatus.CREATED).body(userService.signUp(request));

--- a/src/main/java/com/pawpawlog/user/dto/request/SignUpRequest.java
+++ b/src/main/java/com/pawpawlog/user/dto/request/SignUpRequest.java
@@ -1,23 +1,27 @@
 package com.pawpawlog.user.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 
 public record SignUpRequest(
 
+    @Schema(description = "아이디 (영문자 / 숫자만 허용, 4 ~ 50자)")
     @NotBlank(message = "아이디는 필수값입니다.")
     @Size(min = 4, max = 50, message = "아이디는 4자 이상 50자 이하로 입력해주세요.")
     @Pattern(regexp = "^[a-zA-Z0-9]+$", message = "아이디는 영문자와 숫자만 입력할 수 있습니다.")
     String username,
 
+    @Schema(description = "비밀번호 (영문자 / 숫자 / @ 또는 ! 포함, 8 ~ 20자)")
     @NotBlank(message = "비밀번호는 필수값입니다.")
     @Pattern(
         regexp = "^(?=.*[a-zA-Z])(?=.*[0-9])(?=.*[@!])[a-zA-Z0-9@!]{8,20}$",
-        message = "비밀번호는 영문, 숫자, @ 또는 ! 특수문자를 포함한 8자 이상 20자 이하로 입력해주세요."
+        message = "비밀번호는 영문자, 숫자, @ 또는 ! 특수문자를 포함한 8자 이상 20자 이하로 입력해주세요."
     )
     String password,
 
+    @Schema(description = "닉네임 (2 ~ 30자)")
     @NotBlank(message = "닉네임은 필수값입니다.")
     @Size(min = 2, max = 30, message = "닉네임은 2자 이상 30자 이하로 입력해주세요.")
     String nickname

--- a/src/main/java/com/pawpawlog/user/dto/response/UserResponse.java
+++ b/src/main/java/com/pawpawlog/user/dto/response/UserResponse.java
@@ -2,13 +2,14 @@ package com.pawpawlog.user.dto.response;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.pawpawlog.user.entity.User;
+import io.swagger.v3.oas.annotations.media.Schema;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public record UserResponse(
-    Long id,
-    String username,
-    String nickname,
-    String profileImageUrl
+    @Schema(description = "사용자 ID") Long id,
+    @Schema(description = "아이디") String username,
+    @Schema(description = "닉네임") String nickname,
+    @Schema(description = "프로필 이미지 URL") String profileImageUrl
 ) {
 
   public static UserResponse from(User user) {

--- a/src/main/java/com/pawpawlog/user/dto/response/UsernameAvailabilityResponse.java
+++ b/src/main/java/com/pawpawlog/user/dto/response/UsernameAvailabilityResponse.java
@@ -1,6 +1,10 @@
 package com.pawpawlog.user.dto.response;
 
-public record UsernameAvailabilityResponse(boolean available) {
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record UsernameAvailabilityResponse(
+    @Schema(description = "아이디 사용 가능 여부") boolean available
+) {
 
   public static UsernameAvailabilityResponse from(boolean exists) {
     return new UsernameAvailabilityResponse(!exists);

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -1,0 +1,14 @@
+spring:
+  jpa:
+    show-sql: false
+    hibernate:
+      ddl-auto: validate
+    properties:
+      hibernate:
+        format_sql: false
+
+springdoc:
+  api-docs:
+    enabled: false
+  swagger-ui:
+    enabled: false

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -18,6 +18,9 @@ spring:
         format_sql: true
     open-in-view: false
 
+  jackson:
+    time-zone: Asia/Seoul
+
   data:
     redis:
       host: ${REDIS_HOST}


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- #20

## 📝 작업 내용

- springdoc-openapi 의존성 추가 및 SwaggerConfig 설정
- Auth / User 컨트롤러에 `@Tag`, `@Operation`, `@ApiResponses` 어노테이션 추가
- DTO 및 ErrorResponse에 `@Schema` 어노테이션 추가
- HealthController `@Hidden` 처리 (문서에서 제외)
- application-prod.yml 추가 (prod 환경에서 Swagger UI / api-docs 비활성화)
- Jackson 타임존 Asia/Seoul 설정 추가