### PR TITLE
반려동물 등록 및 관리 API 구현

### DIFF
--- a/src/main/java/com/pawpawlog/auth/dto/request/LoginRequest.java
+++ b/src/main/java/com/pawpawlog/auth/dto/request/LoginRequest.java
@@ -3,8 +3,8 @@ package com.pawpawlog.auth.dto.request;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 public record LoginRequest(
-    @Schema(description = "아이디") String username,
-    @Schema(description = "비밀번호") String password
+    @Schema(description = "아이디", requiredMode = Schema.RequiredMode.REQUIRED) String username,
+    @Schema(description = "비밀번호", requiredMode = Schema.RequiredMode.REQUIRED) String password
 ) {
 
 }

--- a/src/main/java/com/pawpawlog/global/config/SecurityConfig.java
+++ b/src/main/java/com/pawpawlog/global/config/SecurityConfig.java
@@ -32,9 +32,9 @@ import tools.jackson.databind.ObjectMapper;
 @RequiredArgsConstructor
 public class SecurityConfig {
 
-  public static final String[] WHITE_LIST = {
+  private static final String[] WHITE_LIST = {
       "/auth/login", "/auth/reissue", "/auth/logout",
-      "/users", "/users/usernames/*", "/health",
+      "/health",
       "/swagger-ui/**", "/v3/api-docs/**",
       "/oauth2/**", "/login/oauth2/**"
   };
@@ -65,7 +65,7 @@ public class SecurityConfig {
         authenticationManager, authService, objectMapper);
 
     JwtAuthenticationFilter jwtAuthenticationFilter = new JwtAuthenticationFilter(
-        jwtTokenProvider, redisDao, objectMapper);
+        jwtTokenProvider, redisDao, objectMapper, WHITE_LIST);
 
     http
         .csrf(AbstractHttpConfigurer::disable)
@@ -74,7 +74,7 @@ public class SecurityConfig {
         .authorizeHttpRequests(auth ->
             auth
                 .requestMatchers(HttpMethod.POST, "/auth/login", "/auth/reissue", "/auth/logout",
-                    "/users").permitAll()
+                    "/").permitAll()
                 .requestMatchers(HttpMethod.GET, "/users/usernames/*", "/health").permitAll()
                 .requestMatchers("/swagger-ui/**", "/v3/api-docs/**", "/oauth2/**",
                     "/login/oauth2/**").permitAll()

--- a/src/main/java/com/pawpawlog/global/exception/ErrorCode.java
+++ b/src/main/java/com/pawpawlog/global/exception/ErrorCode.java
@@ -11,6 +11,11 @@ public enum ErrorCode {
   DUPLICATE_USERNAME(HttpStatus.CONFLICT, "이미 사용 중인 아이디입니다."),
   USER_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 유저입니다."),
 
+  // Pet
+  PET_NOT_FOUND(HttpStatus.NOT_FOUND, "반려동물을 찾을 수 없습니다."),
+  PET_LIMIT_EXCEEDED(HttpStatus.BAD_REQUEST, "반려동물은 최대 5마리까지 등록할 수 있습니다."),
+  PET_IS_CURRENT(HttpStatus.BAD_REQUEST, "대표 반려동물은 삭제할 수 없습니다. 다른 반려동물을 대표로 지정해주세요."),
+
   // Auth
   UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "로그인이 필요합니다."),
   FORBIDDEN(HttpStatus.FORBIDDEN, "접근 권한이 없습니다."),

--- a/src/main/java/com/pawpawlog/global/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/pawpawlog/global/jwt/JwtAuthenticationFilter.java
@@ -1,6 +1,5 @@
 package com.pawpawlog.global.jwt;
 
-import com.pawpawlog.global.config.SecurityConfig;
 import com.pawpawlog.global.exception.CustomException;
 import com.pawpawlog.global.exception.ErrorCode;
 import com.pawpawlog.global.redis.RedisDao;
@@ -27,6 +26,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
   private final JwtTokenProvider jwtTokenProvider;
   private final RedisDao redisDao;
   private final ObjectMapper objectMapper;
+  private final String[] whiteList;
 
   private static final String AUTHORIZATION_HEADER = "Authorization";
   private static final String BEARER_PREFIX = "Bearer ";
@@ -35,7 +35,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
   @Override
   protected boolean shouldNotFilter(HttpServletRequest request) {
     String path = request.getServletPath();
-    return Arrays.stream(SecurityConfig.WHITE_LIST)
+    return Arrays.stream(whiteList)
         .anyMatch(pattern -> pathMatcher.match(pattern, path));
   }
 

--- a/src/main/java/com/pawpawlog/pet/controller/PetController.java
+++ b/src/main/java/com/pawpawlog/pet/controller/PetController.java
@@ -1,0 +1,118 @@
+package com.pawpawlog.pet.controller;
+
+import com.pawpawlog.global.response.ErrorResponse;
+import com.pawpawlog.global.security.CustomUserDetails;
+import com.pawpawlog.pet.dto.request.PetCreateRequest;
+import com.pawpawlog.pet.dto.request.PetUpdateRequest;
+import com.pawpawlog.pet.dto.response.PetResponse;
+import com.pawpawlog.pet.service.PetService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "Pet", description = "반려동물 관련 API")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/pets")
+public class PetController {
+
+  private final PetService petService;
+
+  @SecurityRequirement(name = "BearerAuth")
+  @Operation(summary = "반려동물 등록", description = "반려동물을 등록합니다. 첫 등록 시 대표 펫으로 자동 지정됩니다.")
+  @ApiResponses({
+      @ApiResponse(responseCode = "201", description = "등록 성공", content = @Content(mediaType = "application/json", schema = @Schema(implementation = PetResponse.class))),
+      @ApiResponse(responseCode = "400", description = "입력값 유효성 오류 또는 5마리 초과", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))),
+      @ApiResponse(responseCode = "401", description = "인증 실패", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class)))
+  })
+  @PostMapping
+  public ResponseEntity<PetResponse> register(
+      @AuthenticationPrincipal CustomUserDetails userDetails,
+      @RequestBody @Valid PetCreateRequest request
+  ) {
+    return ResponseEntity.status(HttpStatus.CREATED)
+        .body(petService.register(userDetails.getUserId(), request));
+  }
+
+  @SecurityRequirement(name = "BearerAuth")
+  @Operation(summary = "반려동물 목록 조회", description = "로그인한 사용자의 반려동물 전체를 조회합니다.")
+  @ApiResponses({
+      @ApiResponse(responseCode = "200", description = "조회 성공", content = @Content(mediaType = "application/json", array = @ArraySchema(schema = @Schema(implementation = PetResponse.class)))),
+      @ApiResponse(responseCode = "401", description = "인증 실패", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class)))
+  })
+  @GetMapping
+  public ResponseEntity<List<PetResponse>> getAll(
+      @AuthenticationPrincipal CustomUserDetails userDetails
+  ) {
+    return ResponseEntity.ok(petService.getAll(userDetails.getUserId()));
+  }
+
+  @SecurityRequirement(name = "BearerAuth")
+  @Operation(summary = "대표 펫 지정", description = "특정 반려동물을 대표 펫으로 지정합니다. 기존 대표 펫은 자동으로 해제됩니다.")
+  @ApiResponses({
+      @ApiResponse(responseCode = "200", description = "지정 성공", content = @Content(mediaType = "application/json", schema = @Schema(implementation = PetResponse.class))),
+      @ApiResponse(responseCode = "401", description = "인증 실패", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))),
+      @ApiResponse(responseCode = "404", description = "반려동물을 찾을 수 없음", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class)))
+  })
+  @PutMapping("/{petId}/current")
+  public ResponseEntity<PetResponse> designateCurrent(
+      @AuthenticationPrincipal CustomUserDetails userDetails,
+      @PathVariable Long petId
+  ) {
+    return ResponseEntity.ok(petService.designateCurrent(userDetails.getUserId(), petId));
+  }
+
+  @SecurityRequirement(name = "BearerAuth")
+  @Operation(summary = "반려동물 정보 수정", description = "반려동물의 이름과 생일을 수정합니다.")
+  @ApiResponses({
+      @ApiResponse(responseCode = "200", description = "수정 성공", content = @Content(mediaType = "application/json", schema = @Schema(implementation = PetResponse.class))),
+      @ApiResponse(responseCode = "400", description = "입력값 유효성 오류", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))),
+      @ApiResponse(responseCode = "401", description = "인증 실패", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))),
+      @ApiResponse(responseCode = "404", description = "반려동물을 찾을 수 없음", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class)))
+  })
+  @PatchMapping("/{petId}")
+  public ResponseEntity<PetResponse> update(
+      @AuthenticationPrincipal CustomUserDetails userDetails,
+      @PathVariable Long petId,
+      @RequestBody @Valid PetUpdateRequest request
+  ) {
+    return ResponseEntity.ok(petService.update(userDetails.getUserId(), petId, request));
+  }
+
+  @SecurityRequirement(name = "BearerAuth")
+  @Operation(summary = "반려동물 삭제", description = "반려동물을 삭제합니다. 대표 펫은 다른 펫이 있을 경우 삭제할 수 없습니다.")
+  @ApiResponses({
+      @ApiResponse(responseCode = "204", description = "삭제 성공"),
+      @ApiResponse(responseCode = "400", description = "대표 펫은 다른 펫이 있을 경우 삭제 불가", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))),
+      @ApiResponse(responseCode = "401", description = "인증 실패", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))),
+      @ApiResponse(responseCode = "404", description = "반려동물을 찾을 수 없음", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class)))
+  })
+  @DeleteMapping("/{petId}")
+  public ResponseEntity<Void> delete(
+      @AuthenticationPrincipal CustomUserDetails userDetails,
+      @PathVariable Long petId
+  ) {
+    petService.delete(userDetails.getUserId(), petId);
+    return ResponseEntity.noContent().build();
+  }
+}

--- a/src/main/java/com/pawpawlog/pet/dto/request/PetCreateRequest.java
+++ b/src/main/java/com/pawpawlog/pet/dto/request/PetCreateRequest.java
@@ -1,0 +1,22 @@
+package com.pawpawlog.pet.dto.request;
+
+import com.pawpawlog.pet.entity.PetType;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import java.time.LocalDate;
+
+public record PetCreateRequest(
+    @NotNull
+    @Schema(description = "반려동물 종류", requiredMode = Schema.RequiredMode.REQUIRED)
+    PetType petType,
+
+    @Size(max = 50)
+    @Schema(description = "반려동물 이름 (최대 50자)", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    String name,
+
+    @Schema(description = "반려동물 생일", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    LocalDate birthDate
+) {
+
+}

--- a/src/main/java/com/pawpawlog/pet/dto/request/PetUpdateRequest.java
+++ b/src/main/java/com/pawpawlog/pet/dto/request/PetUpdateRequest.java
@@ -1,0 +1,16 @@
+package com.pawpawlog.pet.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Size;
+import java.time.LocalDate;
+
+public record PetUpdateRequest(
+    @Size(min = 1, max = 50)
+    @Schema(description = "반려동물 이름 (최대 50자)", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    String name,
+
+    @Schema(description = "반려동물 생일", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    LocalDate birthDate
+) {
+
+}

--- a/src/main/java/com/pawpawlog/pet/dto/response/PetResponse.java
+++ b/src/main/java/com/pawpawlog/pet/dto/response/PetResponse.java
@@ -1,0 +1,25 @@
+package com.pawpawlog.pet.dto.response;
+
+import com.pawpawlog.pet.entity.Pet;
+import com.pawpawlog.pet.entity.PetType;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDate;
+
+public record PetResponse(
+    @Schema(description = "반려동물 ID") Long id,
+    @Schema(description = "반려동물 종류") PetType petType,
+    @Schema(description = "반려동물 이름") String name,
+    @Schema(description = "반려동물 생일") LocalDate birthDate,
+    @Schema(description = "대표 펫 여부") boolean isCurrent
+) {
+
+  public static PetResponse from(Pet pet) {
+    return new PetResponse(
+        pet.getId(),
+        pet.getPetType(),
+        pet.getName(),
+        pet.getBirthDate(),
+        pet.isCurrent()
+    );
+  }
+}

--- a/src/main/java/com/pawpawlog/pet/entity/Pet.java
+++ b/src/main/java/com/pawpawlog/pet/entity/Pet.java
@@ -40,7 +40,7 @@ public class Pet extends BaseEntity {
   @Column(nullable = false, length = 20)
   private PetType petType;
 
-  @Column(nullable = false, length = 50)
+  @Column(length = 50)
   private String name;
 
   private LocalDate birthDate;
@@ -57,7 +57,7 @@ public class Pet extends BaseEntity {
     this.birthDate = birthDate;
   }
 
-  public void setCurrent(boolean isCurrent) {
+  public void updateCurrent(boolean isCurrent) {
     this.isCurrent = isCurrent;
   }
 }

--- a/src/main/java/com/pawpawlog/pet/repository/PetRepository.java
+++ b/src/main/java/com/pawpawlog/pet/repository/PetRepository.java
@@ -1,0 +1,16 @@
+package com.pawpawlog.pet.repository;
+
+import com.pawpawlog.pet.entity.Pet;
+import com.pawpawlog.user.entity.User;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PetRepository extends JpaRepository<Pet, Long> {
+
+  List<Pet> findAllByUser(User user);
+
+  long countByUser(User user);
+
+  Optional<Pet> findByIdAndUser(Long id, User user);
+}

--- a/src/main/java/com/pawpawlog/pet/service/PetService.java
+++ b/src/main/java/com/pawpawlog/pet/service/PetService.java
@@ -65,9 +65,6 @@ public class PetService {
     User user = getUser(userId);
     Pet pet = petRepository.findByIdAndUser(petId, user)
         .orElseThrow(() -> new CustomException(ErrorCode.PET_NOT_FOUND));
-    if (request.name() == null && request.birthDate() == null) {
-      throw new CustomException(ErrorCode.INVALID_INPUT);
-    }
     if (request.name() != null) {
       pet.updateName(request.name());
     }

--- a/src/main/java/com/pawpawlog/pet/service/PetService.java
+++ b/src/main/java/com/pawpawlog/pet/service/PetService.java
@@ -1,0 +1,95 @@
+package com.pawpawlog.pet.service;
+
+import com.pawpawlog.global.exception.CustomException;
+import com.pawpawlog.global.exception.ErrorCode;
+import com.pawpawlog.pet.dto.request.PetCreateRequest;
+import com.pawpawlog.pet.dto.request.PetUpdateRequest;
+import com.pawpawlog.pet.dto.response.PetResponse;
+import com.pawpawlog.pet.entity.Pet;
+import com.pawpawlog.pet.repository.PetRepository;
+import com.pawpawlog.user.entity.User;
+import com.pawpawlog.user.repository.UserRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class PetService {
+
+  private static final int MAX_PET_COUNT = 5;
+
+  private final PetRepository petRepository;
+  private final UserRepository userRepository;
+
+  @Transactional
+  public PetResponse register(Long userId, PetCreateRequest request) {
+    User user = getUser(userId);
+    long count = petRepository.countByUser(user);
+    if (count >= MAX_PET_COUNT) {
+      throw new CustomException(ErrorCode.PET_LIMIT_EXCEEDED);
+    }
+    Pet pet = Pet.builder()
+        .user(user)
+        .petType(request.petType())
+        .name(request.name())
+        .birthDate(request.birthDate())
+        .isCurrent(count == 0)
+        .build();
+    return PetResponse.from(petRepository.save(pet));
+  }
+
+  public List<PetResponse> getAll(Long userId) {
+    User user = getUser(userId);
+    return petRepository.findAllByUser(user).stream()
+        .map(PetResponse::from)
+        .toList();
+  }
+
+  @Transactional
+  public PetResponse designateCurrent(Long userId, Long petId) {
+    User user = getUser(userId);
+    Pet target = petRepository.findByIdAndUser(petId, user)
+        .orElseThrow(() -> new CustomException(ErrorCode.PET_NOT_FOUND));
+    petRepository.findAllByUser(user).stream()
+        .filter(Pet::isCurrent)
+        .forEach(p -> p.updateCurrent(false));
+    target.updateCurrent(true);
+    return PetResponse.from(target);
+  }
+
+  @Transactional
+  public PetResponse update(Long userId, Long petId, PetUpdateRequest request) {
+    User user = getUser(userId);
+    Pet pet = petRepository.findByIdAndUser(petId, user)
+        .orElseThrow(() -> new CustomException(ErrorCode.PET_NOT_FOUND));
+    if (request.name() == null && request.birthDate() == null) {
+      throw new CustomException(ErrorCode.INVALID_INPUT);
+    }
+    if (request.name() != null) {
+      pet.updateName(request.name());
+    }
+    if (request.birthDate() != null) {
+      pet.updateBirthDate(request.birthDate());
+    }
+    return PetResponse.from(pet);
+  }
+
+  @Transactional
+  public void delete(Long userId, Long petId) {
+    User user = getUser(userId);
+    Pet pet = petRepository.findByIdAndUser(petId, user)
+        .orElseThrow(() -> new CustomException(ErrorCode.PET_NOT_FOUND));
+    if (pet.isCurrent() && petRepository.countByUser(user) > 1) {
+      throw new CustomException(ErrorCode.PET_IS_CURRENT);
+    }
+    petRepository.delete(pet);
+  }
+
+  private User getUser(Long userId) {
+    return userRepository.findById(userId)
+        .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+  }
+}

--- a/src/main/java/com/pawpawlog/user/controller/UserController.java
+++ b/src/main/java/com/pawpawlog/user/controller/UserController.java
@@ -36,8 +36,7 @@ public class UserController {
   @GetMapping("/usernames/{username}")
   public ResponseEntity<UsernameAvailabilityResponse> checkUsernameAvailability(
       @PathVariable String username) {
-    return ResponseEntity.ok(
-        UsernameAvailabilityResponse.from(userService.existsByUsername(username)));
+    return ResponseEntity.ok(userService.checkUsernameAvailability(username));
   }
 
   @Operation(summary = "회원가입", description = "username / password / nickname으로 신규 계정을 생성합니다.")

--- a/src/main/java/com/pawpawlog/user/dto/request/SignUpRequest.java
+++ b/src/main/java/com/pawpawlog/user/dto/request/SignUpRequest.java
@@ -7,13 +7,13 @@ import jakarta.validation.constraints.Size;
 
 public record SignUpRequest(
 
-    @Schema(description = "아이디 (영문자 / 숫자만 허용, 4 ~ 50자)")
+    @Schema(description = "아이디 (영문자 / 숫자만 허용, 4 ~ 50자)", requiredMode = Schema.RequiredMode.REQUIRED)
     @NotBlank(message = "아이디는 필수값입니다.")
     @Size(min = 4, max = 50, message = "아이디는 4자 이상 50자 이하로 입력해주세요.")
     @Pattern(regexp = "^[a-zA-Z0-9]+$", message = "아이디는 영문자와 숫자만 입력할 수 있습니다.")
     String username,
 
-    @Schema(description = "비밀번호 (영문자 / 숫자 / @ 또는 ! 포함, 8 ~ 20자)")
+    @Schema(description = "비밀번호 (영문자 / 숫자 / @ 또는 ! 포함, 8 ~ 20자)", requiredMode = Schema.RequiredMode.REQUIRED)
     @NotBlank(message = "비밀번호는 필수값입니다.")
     @Pattern(
         regexp = "^(?=.*[a-zA-Z])(?=.*[0-9])(?=.*[@!])[a-zA-Z0-9@!]{8,20}$",
@@ -21,7 +21,7 @@ public record SignUpRequest(
     )
     String password,
 
-    @Schema(description = "닉네임 (2 ~ 30자)")
+    @Schema(description = "닉네임 (2 ~ 30자)", requiredMode = Schema.RequiredMode.REQUIRED)
     @NotBlank(message = "닉네임은 필수값입니다.")
     @Size(min = 2, max = 30, message = "닉네임은 2자 이상 30자 이하로 입력해주세요.")
     String nickname

--- a/src/main/java/com/pawpawlog/user/entity/User.java
+++ b/src/main/java/com/pawpawlog/user/entity/User.java
@@ -82,7 +82,6 @@ public class User extends BaseEntity {
     this.profileImageUrl = profileImageUrl;
   }
 
-  // equals & hashCode
   @Override
   public boolean equals(Object o) {
     if (this == o) {

--- a/src/main/java/com/pawpawlog/user/service/UserService.java
+++ b/src/main/java/com/pawpawlog/user/service/UserService.java
@@ -4,6 +4,7 @@ import com.pawpawlog.global.exception.CustomException;
 import com.pawpawlog.global.exception.ErrorCode;
 import com.pawpawlog.user.dto.request.SignUpRequest;
 import com.pawpawlog.user.dto.response.UserResponse;
+import com.pawpawlog.user.dto.response.UsernameAvailabilityResponse;
 import com.pawpawlog.user.entity.Provider;
 import com.pawpawlog.user.entity.User;
 import com.pawpawlog.user.repository.UserRepository;
@@ -21,8 +22,8 @@ public class UserService {
   private final UserRepository userRepository;
   private final PasswordEncoder passwordEncoder;
 
-  public boolean existsByUsername(String username) {
-    return userRepository.existsByUsername(username);
+  public UsernameAvailabilityResponse checkUsernameAvailability(String username) {
+    return UsernameAvailabilityResponse.from(userRepository.existsByUsername(username));
   }
 
   public Optional<User> findByProviderAndProviderId(Provider provider, String providerId) {


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- #17 

## 📝 작업 내용

- Pet CRUD API 구현 (`POST /pets`, `GET /pets`, `PATCH /pets/{petId}`, `DELETE /pets/{petId}`)
- 대표 펫 지정 API 구현 (`PUT /pets/{petId}/current`): 기존 대표 자동 해제 후 새 대표 설정
- 첫 반려동물 등록 시 `isCurrent = true` 자동 적용, 최대 5마리 제한
- 대표 펫 삭제 제한: 다른 펫이 있으면 삭제 불가 (`PET_IS_CURRENT`), 유일한 펫이면 삭제 허용
- `PetCreateRequest`, `PetUpdateRequest`, `PetResponse` DTO 작성
- `PetRepository`: `findAllByUser`, `countByUser`, `findByIdAndUser`
- `ErrorCode`에 `PET_NOT_FOUND`, `PET_LIMIT_EXCEEDED`, `PET_IS_CURRENT` 추가
- 전체 엔드포인트에 Swagger 문서화 적용