### PR TITLE
PetCreateRequest에서 name / birthDate 제거

### DIFF
--- a/src/main/java/com/pawpawlog/pet/dto/request/PetCreateRequest.java
+++ b/src/main/java/com/pawpawlog/pet/dto/request/PetCreateRequest.java
@@ -3,20 +3,11 @@ package com.pawpawlog.pet.dto.request;
 import com.pawpawlog.pet.entity.PetType;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Size;
-import java.time.LocalDate;
 
 public record PetCreateRequest(
     @NotNull
     @Schema(description = "반려동물 종류", requiredMode = Schema.RequiredMode.REQUIRED)
-    PetType petType,
-
-    @Size(max = 50)
-    @Schema(description = "반려동물 이름 (최대 50자)", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-    String name,
-
-    @Schema(description = "반려동물 생일", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-    LocalDate birthDate
+    PetType petType
 ) {
 
 }

--- a/src/main/java/com/pawpawlog/pet/service/PetService.java
+++ b/src/main/java/com/pawpawlog/pet/service/PetService.java
@@ -34,8 +34,6 @@ public class PetService {
     Pet pet = Pet.builder()
         .user(user)
         .petType(request.petType())
-        .name(request.name())
-        .birthDate(request.birthDate())
         .isCurrent(count == 0)
         .build();
     return PetResponse.from(petRepository.save(pet));


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- #25

## 📝 작업 내용

- `PetCreateRequest`에서 `name`, `birthDate` 필드 제거
- 반려동물 등록 시 `petType`만 입력받도록 변경
- `name`, `birthDate`는 등록 후 `PATCH /pets/{petId}`로만 수정 가능