### PR TITLE
반려동물 다이어리 CRUD API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ description = 'Demo project for Spring Boot'
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(17)
+        languageVersion = JavaLanguageVersion.of(21)
     }
 }
 
@@ -45,6 +45,8 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+    developmentOnly 'org.springframework.boot:spring-boot-devtools'
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,7 @@ repositories {
 }
 
 dependencies {
-    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.9'
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:3.0.3'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-security'

--- a/src/main/java/com/pawpawlog/auth/controller/AuthController.java
+++ b/src/main/java/com/pawpawlog/auth/controller/AuthController.java
@@ -1,5 +1,6 @@
 package com.pawpawlog.auth.controller;
 
+import com.pawpawlog.auth.dto.request.OAuth2CodeExchangeRequest;
 import com.pawpawlog.auth.dto.response.TokenResponse;
 import com.pawpawlog.auth.service.AuthService;
 import com.pawpawlog.global.exception.CustomException;
@@ -12,10 +13,12 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.util.StringUtils;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -29,6 +32,21 @@ public class AuthController {
   private static final String BEARER_PREFIX = "Bearer ";
 
   private final AuthService authService;
+
+  @Operation(summary = "OAuth2 토큰 교환", description = "OAuth2 로그인 콜백에서 받은 1회용 코드를 액세스 / 리프레시 토큰으로 교환합니다.")
+  @ApiResponses({
+      @ApiResponse(responseCode = "200", description = "교환 성공",
+          content = @Content(mediaType = "application/json",
+              schema = @Schema(implementation = TokenResponse.class))),
+      @ApiResponse(responseCode = "401", description = "유효하지 않거나 만료된 코드",
+          content = @Content(mediaType = "application/json",
+              schema = @Schema(implementation = ErrorResponse.class)))
+  })
+  @PostMapping("/oauth2/token")
+  public ResponseEntity<TokenResponse> exchangeOAuth2Code(
+      @RequestBody @Valid OAuth2CodeExchangeRequest request) {
+    return ResponseEntity.ok(authService.exchangeOAuth2Code(request.code()));
+  }
 
   @SecurityRequirement(name = "BearerAuth")
   @Operation(summary = "토큰 재발급", description = "리프레시 토큰으로 액세스 / 리프레시 토큰을 재발급합니다.")

--- a/src/main/java/com/pawpawlog/auth/dto/request/OAuth2CodeExchangeRequest.java
+++ b/src/main/java/com/pawpawlog/auth/dto/request/OAuth2CodeExchangeRequest.java
@@ -1,0 +1,12 @@
+package com.pawpawlog.auth.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+
+public record OAuth2CodeExchangeRequest(
+    @NotBlank(message = "인증 코드는 필수값입니다.")
+    @Schema(description = "OAuth2 로그인 콜백에서 발급받은 1회용 코드", requiredMode = Schema.RequiredMode.REQUIRED)
+    String code
+) {
+
+}

--- a/src/main/java/com/pawpawlog/auth/oauth2/CustomOAuth2UserService.java
+++ b/src/main/java/com/pawpawlog/auth/oauth2/CustomOAuth2UserService.java
@@ -4,7 +4,9 @@ import com.pawpawlog.auth.oauth2.userinfo.GoogleOAuth2UserInfo;
 import com.pawpawlog.auth.oauth2.userinfo.KakaoOAuth2UserInfo;
 import com.pawpawlog.auth.oauth2.userinfo.NaverOAuth2UserInfo;
 import com.pawpawlog.auth.oauth2.userinfo.OAuth2UserInfo;
+import com.pawpawlog.global.exception.ErrorCode;
 import com.pawpawlog.user.entity.User;
+import com.pawpawlog.user.entity.UserStatus;
 import com.pawpawlog.user.service.UserService;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
@@ -53,10 +55,22 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
   private User saveOrUpdate(OAuth2UserInfo userInfo) {
     return userService.findByProviderAndProviderId(userInfo.getProvider(), userInfo.getProviderId())
         .map(user -> {
+          validateActive(user);
           user.updateProfileImage(userInfo.getProfileImageUrl());
           return user;
         })
         .orElseGet(() -> createUser(userInfo));
+  }
+
+  private void validateActive(User user) {
+    if (user.getStatus() == UserStatus.SUSPENDED) {
+      throw new OAuth2AuthenticationException(
+          new OAuth2Error("account_suspended", ErrorCode.ACCOUNT_SUSPENDED.getMessage(), null));
+    }
+    if (user.getStatus() == UserStatus.DELETED) {
+      throw new OAuth2AuthenticationException(
+          new OAuth2Error("account_deleted", ErrorCode.ACCOUNT_DELETED.getMessage(), null));
+    }
   }
 
   private User createUser(OAuth2UserInfo userInfo) {

--- a/src/main/java/com/pawpawlog/auth/oauth2/handler/OAuth2LoginSuccessHandler.java
+++ b/src/main/java/com/pawpawlog/auth/oauth2/handler/OAuth2LoginSuccessHandler.java
@@ -1,11 +1,11 @@
 package com.pawpawlog.auth.oauth2.handler;
 
-import com.pawpawlog.auth.dto.response.TokenResponse;
 import com.pawpawlog.auth.oauth2.CustomOAuth2User;
-import com.pawpawlog.auth.service.AuthService;
+import com.pawpawlog.global.redis.RedisDao;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -22,7 +22,10 @@ public class OAuth2LoginSuccessHandler extends SimpleUrlAuthenticationSuccessHan
   @Value("${app.oauth2.redirect-uri}")
   private String redirectUri;
 
-  private final AuthService authService;
+  @Value("${app.oauth2.code-expiration}")
+  private long codeExpirationMillis;
+
+  private final RedisDao redisDao;
 
   @Override
   public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response,
@@ -30,11 +33,11 @@ public class OAuth2LoginSuccessHandler extends SimpleUrlAuthenticationSuccessHan
     CustomOAuth2User oAuth2User = (CustomOAuth2User) authentication.getPrincipal();
     String userId = String.valueOf(oAuth2User.getUserId());
 
-    TokenResponse tokenResponse = authService.issueTokenForUser(userId);
+    String code = UUID.randomUUID().toString();
+    redisDao.saveOAuth2Code(code, userId, codeExpirationMillis);
 
     String targetUrl = UriComponentsBuilder.fromUriString(redirectUri)
-        .queryParam("accessToken", tokenResponse.accessToken())
-        .queryParam("refreshToken", tokenResponse.refreshToken())
+        .queryParam("code", code)
         .build().toUriString();
 
     log.debug("OAuth2 로그인 성공: userId={}", userId);

--- a/src/main/java/com/pawpawlog/auth/service/AuthService.java
+++ b/src/main/java/com/pawpawlog/auth/service/AuthService.java
@@ -35,6 +35,15 @@ public class AuthService {
     return TokenResponse.from(tokenPair);
   }
 
+  public TokenResponse exchangeOAuth2Code(String code) {
+    String userId = redisDao.getUserIdByOAuth2Code(code);
+    if (userId == null) {
+      throw new CustomException(ErrorCode.OAUTH2_CODE_INVALID);
+    }
+    redisDao.deleteOAuth2Code(code);
+    return issueTokenForUser(userId);
+  }
+
   public TokenResponse reissue(String refreshToken) {
     String id = jwtTokenProvider.validateRefreshTokenAndGetId(refreshToken);
 

--- a/src/main/java/com/pawpawlog/diary/controller/DiaryController.java
+++ b/src/main/java/com/pawpawlog/diary/controller/DiaryController.java
@@ -1,0 +1,127 @@
+package com.pawpawlog.diary.controller;
+
+import com.pawpawlog.diary.dto.request.DiaryCreateRequest;
+import com.pawpawlog.diary.dto.request.DiaryUpdateRequest;
+import com.pawpawlog.diary.dto.response.DiaryResponse;
+import com.pawpawlog.diary.service.DiaryService;
+import com.pawpawlog.global.response.ErrorResponse;
+import com.pawpawlog.global.security.CustomUserDetails;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import java.time.YearMonth;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "Diary", description = "반려동물 다이어리 관련 API")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/pets/{petId}/diaries")
+public class DiaryController {
+
+  private final DiaryService diaryService;
+
+  @SecurityRequirement(name = "BearerAuth")
+  @Operation(summary = "다이어리 작성", description = "반려동물의 하루 기록을 작성합니다. 같은 날짜에 중복 작성할 수 없습니다.")
+  @ApiResponses({
+      @ApiResponse(responseCode = "201", description = "작성 성공", content = @Content(mediaType = "application/json", schema = @Schema(implementation = DiaryResponse.class))),
+      @ApiResponse(responseCode = "400", description = "입력값 유효성 오류", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))),
+      @ApiResponse(responseCode = "401", description = "인증 실패", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))),
+      @ApiResponse(responseCode = "404", description = "반려동물을 찾을 수 없음", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))),
+      @ApiResponse(responseCode = "409", description = "해당 날짜에 이미 기록 존재", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class)))
+  })
+  @PostMapping
+  public ResponseEntity<DiaryResponse> create(
+      @AuthenticationPrincipal CustomUserDetails userDetails,
+      @PathVariable Long petId,
+      @RequestBody @Valid DiaryCreateRequest request
+  ) {
+    return ResponseEntity.status(HttpStatus.CREATED)
+        .body(diaryService.create(userDetails.getUserId(), petId, request));
+  }
+
+  @SecurityRequirement(name = "BearerAuth")
+  @Operation(summary = "월별 다이어리 조회", description = "해당 반려동물의 특정 월 다이어리 목록을 조회합니다.")
+  @ApiResponses({
+      @ApiResponse(responseCode = "200", description = "조회 성공", content = @Content(mediaType = "application/json", array = @ArraySchema(schema = @Schema(implementation = DiaryResponse.class)))),
+      @ApiResponse(responseCode = "401", description = "인증 실패", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))),
+      @ApiResponse(responseCode = "404", description = "반려동물을 찾을 수 없음", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class)))
+  })
+  @GetMapping
+  public ResponseEntity<List<DiaryResponse>> getMonthly(
+      @AuthenticationPrincipal CustomUserDetails userDetails,
+      @PathVariable Long petId,
+      @RequestParam YearMonth month
+  ) {
+    return ResponseEntity.ok(diaryService.getMonthly(userDetails.getUserId(), petId, month));
+  }
+
+  @SecurityRequirement(name = "BearerAuth")
+  @Operation(summary = "다이어리 상세 조회", description = "다이어리 단건을 조회합니다.")
+  @ApiResponses({
+      @ApiResponse(responseCode = "200", description = "조회 성공", content = @Content(mediaType = "application/json", schema = @Schema(implementation = DiaryResponse.class))),
+      @ApiResponse(responseCode = "401", description = "인증 실패", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))),
+      @ApiResponse(responseCode = "404", description = "반려동물 또는 다이어리를 찾을 수 없음", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class)))
+  })
+  @GetMapping("/{diaryId}")
+  public ResponseEntity<DiaryResponse> getOne(
+      @AuthenticationPrincipal CustomUserDetails userDetails,
+      @PathVariable Long petId,
+      @PathVariable Long diaryId
+  ) {
+    return ResponseEntity.ok(diaryService.getOne(userDetails.getUserId(), petId, diaryId));
+  }
+
+  @SecurityRequirement(name = "BearerAuth")
+  @Operation(summary = "다이어리 수정", description = "다이어리의 내용과 감정을 수정합니다. 날짜는 수정할 수 없습니다.")
+  @ApiResponses({
+      @ApiResponse(responseCode = "200", description = "수정 성공", content = @Content(mediaType = "application/json", schema = @Schema(implementation = DiaryResponse.class))),
+      @ApiResponse(responseCode = "400", description = "입력값 유효성 오류", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))),
+      @ApiResponse(responseCode = "401", description = "인증 실패", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))),
+      @ApiResponse(responseCode = "404", description = "반려동물 또는 다이어리를 찾을 수 없음", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class)))
+  })
+  @PatchMapping("/{diaryId}")
+  public ResponseEntity<DiaryResponse> update(
+      @AuthenticationPrincipal CustomUserDetails userDetails,
+      @PathVariable Long petId,
+      @PathVariable Long diaryId,
+      @RequestBody @Valid DiaryUpdateRequest request
+  ) {
+    return ResponseEntity.ok(diaryService.update(userDetails.getUserId(), petId, diaryId, request));
+  }
+
+  @SecurityRequirement(name = "BearerAuth")
+  @Operation(summary = "다이어리 삭제", description = "다이어리를 삭제합니다.")
+  @ApiResponses({
+      @ApiResponse(responseCode = "204", description = "삭제 성공"),
+      @ApiResponse(responseCode = "401", description = "인증 실패", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))),
+      @ApiResponse(responseCode = "404", description = "반려동물 또는 다이어리를 찾을 수 없음", content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class)))
+  })
+  @DeleteMapping("/{diaryId}")
+  public ResponseEntity<Void> delete(
+      @AuthenticationPrincipal CustomUserDetails userDetails,
+      @PathVariable Long petId,
+      @PathVariable Long diaryId
+  ) {
+    diaryService.delete(userDetails.getUserId(), petId, diaryId);
+    return ResponseEntity.noContent().build();
+  }
+}

--- a/src/main/java/com/pawpawlog/diary/dto/request/DiaryCreateRequest.java
+++ b/src/main/java/com/pawpawlog/diary/dto/request/DiaryCreateRequest.java
@@ -1,0 +1,25 @@
+package com.pawpawlog.diary.dto.request;
+
+import com.pawpawlog.diary.entity.DiaryEmotion;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.PastOrPresent;
+import java.time.LocalDate;
+
+public record DiaryCreateRequest(
+    @NotNull
+    @PastOrPresent
+    @Schema(description = "기록 날짜 (오늘 이전 또는 오늘)", requiredMode = Schema.RequiredMode.REQUIRED)
+    LocalDate diaryDate,
+
+    @NotBlank
+    @Schema(description = "다이어리 내용", requiredMode = Schema.RequiredMode.REQUIRED)
+    String content,
+
+    @NotNull
+    @Schema(description = "감정 픽토그램", requiredMode = Schema.RequiredMode.REQUIRED)
+    DiaryEmotion emotion
+) {
+
+}

--- a/src/main/java/com/pawpawlog/diary/dto/request/DiaryUpdateRequest.java
+++ b/src/main/java/com/pawpawlog/diary/dto/request/DiaryUpdateRequest.java
@@ -2,8 +2,10 @@ package com.pawpawlog.diary.dto.request;
 
 import com.pawpawlog.diary.entity.DiaryEmotion;
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Pattern;
 
 public record DiaryUpdateRequest(
+    @Pattern(regexp = "(?s).*\\S.*", message = "공백일 수 없습니다.")
     @Schema(description = "다이어리 내용", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
     String content,
 

--- a/src/main/java/com/pawpawlog/diary/dto/request/DiaryUpdateRequest.java
+++ b/src/main/java/com/pawpawlog/diary/dto/request/DiaryUpdateRequest.java
@@ -1,0 +1,14 @@
+package com.pawpawlog.diary.dto.request;
+
+import com.pawpawlog.diary.entity.DiaryEmotion;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record DiaryUpdateRequest(
+    @Schema(description = "다이어리 내용", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    String content,
+
+    @Schema(description = "감정 픽토그램", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    DiaryEmotion emotion
+) {
+
+}

--- a/src/main/java/com/pawpawlog/diary/dto/response/DiaryResponse.java
+++ b/src/main/java/com/pawpawlog/diary/dto/response/DiaryResponse.java
@@ -1,0 +1,30 @@
+package com.pawpawlog.diary.dto.response;
+
+import com.pawpawlog.diary.entity.Diary;
+import com.pawpawlog.diary.entity.DiaryEmotion;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+public record DiaryResponse(
+    @Schema(description = "다이어리 ID") Long id,
+    @Schema(description = "반려동물 ID") Long petId,
+    @Schema(description = "기록 날짜") LocalDate diaryDate,
+    @Schema(description = "내용") String content,
+    @Schema(description = "감정 픽토그램") DiaryEmotion emotion,
+    @Schema(description = "생성일시") LocalDateTime createdAt,
+    @Schema(description = "수정일시") LocalDateTime updatedAt
+) {
+
+  public static DiaryResponse from(Diary diary) {
+    return new DiaryResponse(
+        diary.getId(),
+        diary.getPet().getId(),
+        diary.getDiaryDate(),
+        diary.getContent(),
+        diary.getEmotion(),
+        diary.getCreatedAt(),
+        diary.getUpdatedAt()
+    );
+  }
+}

--- a/src/main/java/com/pawpawlog/diary/entity/Diary.java
+++ b/src/main/java/com/pawpawlog/diary/entity/Diary.java
@@ -1,0 +1,62 @@
+package com.pawpawlog.diary.entity;
+
+import com.pawpawlog.global.domain.BaseEntity;
+import com.pawpawlog.pet.entity.Pet;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import java.time.LocalDate;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(
+    name = "diaries",
+    uniqueConstraints = {
+        @UniqueConstraint(columnNames = {"pet_id", "diary_date"})
+    }
+)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class Diary extends BaseEntity {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "pet_id", nullable = false)
+  private Pet pet;
+
+  @Column(name = "diary_date", nullable = false)
+  private LocalDate diaryDate;
+
+  @Column(nullable = false, columnDefinition = "TEXT")
+  private String content;
+
+  @Enumerated(EnumType.STRING)
+  @Column(nullable = false, length = 20)
+  private DiaryEmotion emotion;
+
+  public void updateContent(String content) {
+    this.content = content;
+  }
+
+  public void updateEmotion(DiaryEmotion emotion) {
+    this.emotion = emotion;
+  }
+}

--- a/src/main/java/com/pawpawlog/diary/entity/DiaryEmotion.java
+++ b/src/main/java/com/pawpawlog/diary/entity/DiaryEmotion.java
@@ -1,0 +1,9 @@
+package com.pawpawlog.diary.entity;
+
+public enum DiaryEmotion {
+  VERY_HAPPY,
+  HAPPY,
+  NEUTRAL,
+  SAD,
+  VERY_SAD
+}

--- a/src/main/java/com/pawpawlog/diary/repository/DiaryRepository.java
+++ b/src/main/java/com/pawpawlog/diary/repository/DiaryRepository.java
@@ -1,0 +1,17 @@
+package com.pawpawlog.diary.repository;
+
+import com.pawpawlog.diary.entity.Diary;
+import com.pawpawlog.pet.entity.Pet;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface DiaryRepository extends JpaRepository<Diary, Long> {
+
+  Optional<Diary> findByIdAndPet(Long id, Pet pet);
+
+  List<Diary> findAllByPetAndDiaryDateBetween(Pet pet, LocalDate start, LocalDate end);
+
+  boolean existsByPetAndDiaryDate(Pet pet, LocalDate diaryDate);
+}

--- a/src/main/java/com/pawpawlog/diary/service/DiaryService.java
+++ b/src/main/java/com/pawpawlog/diary/service/DiaryService.java
@@ -1,0 +1,91 @@
+package com.pawpawlog.diary.service;
+
+import com.pawpawlog.diary.dto.request.DiaryCreateRequest;
+import com.pawpawlog.diary.dto.request.DiaryUpdateRequest;
+import com.pawpawlog.diary.dto.response.DiaryResponse;
+import com.pawpawlog.diary.entity.Diary;
+import com.pawpawlog.diary.repository.DiaryRepository;
+import com.pawpawlog.global.exception.CustomException;
+import com.pawpawlog.global.exception.ErrorCode;
+import com.pawpawlog.pet.entity.Pet;
+import com.pawpawlog.pet.repository.PetRepository;
+import com.pawpawlog.user.entity.User;
+import com.pawpawlog.user.repository.UserRepository;
+import java.time.LocalDate;
+import java.time.YearMonth;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class DiaryService {
+
+  private final DiaryRepository diaryRepository;
+  private final PetRepository petRepository;
+  private final UserRepository userRepository;
+
+  @Transactional
+  public DiaryResponse create(Long userId, Long petId, DiaryCreateRequest request) {
+    Pet pet = getPet(userId, petId);
+    if (diaryRepository.existsByPetAndDiaryDate(pet, request.diaryDate())) {
+      throw new CustomException(ErrorCode.DIARY_ALREADY_EXISTS);
+    }
+    Diary diary = Diary.builder()
+        .pet(pet)
+        .diaryDate(request.diaryDate())
+        .content(request.content())
+        .emotion(request.emotion())
+        .build();
+    return DiaryResponse.from(diaryRepository.save(diary));
+  }
+
+  public List<DiaryResponse> getMonthly(Long userId, Long petId, YearMonth month) {
+    Pet pet = getPet(userId, petId);
+    LocalDate start = month.atDay(1);
+    LocalDate end = month.atEndOfMonth();
+    return diaryRepository.findAllByPetAndDiaryDateBetween(pet, start, end).stream()
+        .map(DiaryResponse::from)
+        .toList();
+  }
+
+  public DiaryResponse getOne(Long userId, Long petId, Long diaryId) {
+    return DiaryResponse.from(getDiary(userId, petId, diaryId));
+  }
+
+  @Transactional
+  public DiaryResponse update(Long userId, Long petId, Long diaryId, DiaryUpdateRequest request) {
+    Diary diary = getDiary(userId, petId, diaryId);
+    if (request.content() != null) {
+      diary.updateContent(request.content());
+    }
+    if (request.emotion() != null) {
+      diary.updateEmotion(request.emotion());
+    }
+    return DiaryResponse.from(diary);
+  }
+
+  @Transactional
+  public void delete(Long userId, Long petId, Long diaryId) {
+    diaryRepository.delete(getDiary(userId, petId, diaryId));
+  }
+
+  private Diary getDiary(Long userId, Long petId, Long diaryId) {
+    Pet pet = getPet(userId, petId);
+    return diaryRepository.findByIdAndPet(diaryId, pet)
+        .orElseThrow(() -> new CustomException(ErrorCode.DIARY_NOT_FOUND));
+  }
+
+  private Pet getPet(Long userId, Long petId) {
+    User user = getUser(userId);
+    return petRepository.findByIdAndUser(petId, user)
+        .orElseThrow(() -> new CustomException(ErrorCode.PET_NOT_FOUND));
+  }
+
+  private User getUser(Long userId) {
+    return userRepository.findById(userId)
+        .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+  }
+}

--- a/src/main/java/com/pawpawlog/diary/service/DiaryService.java
+++ b/src/main/java/com/pawpawlog/diary/service/DiaryService.java
@@ -15,6 +15,7 @@ import java.time.LocalDate;
 import java.time.YearMonth;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -39,7 +40,11 @@ public class DiaryService {
         .content(request.content())
         .emotion(request.emotion())
         .build();
-    return DiaryResponse.from(diaryRepository.save(diary));
+    try {
+      return DiaryResponse.from(diaryRepository.save(diary));
+    } catch (DataIntegrityViolationException e) {
+      throw new CustomException(ErrorCode.DIARY_ALREADY_EXISTS);
+    }
   }
 
   public List<DiaryResponse> getMonthly(Long userId, Long petId, YearMonth month) {

--- a/src/main/java/com/pawpawlog/global/config/SecurityConfig.java
+++ b/src/main/java/com/pawpawlog/global/config/SecurityConfig.java
@@ -35,7 +35,7 @@ import tools.jackson.databind.ObjectMapper;
 public class SecurityConfig {
 
   private static final String[] WHITE_LIST = {
-      "/auth/login", "/auth/reissue", "/auth/logout",
+      "/auth/login", "/auth/reissue", "/auth/logout", "/auth/oauth2/token",
       "/health",
       "/swagger-ui/**", "/v3/api-docs/**",
       "/oauth2/**", "/login/oauth2/**"
@@ -78,7 +78,7 @@ public class SecurityConfig {
         .authorizeHttpRequests(auth ->
             auth
                 .requestMatchers(HttpMethod.POST, "/auth/login", "/auth/reissue", "/auth/logout",
-                    "/users", "/").permitAll()
+                    "/auth/oauth2/token", "/users", "/").permitAll()
                 .requestMatchers(HttpMethod.GET, "/users/usernames/*", "/health").permitAll()
                 .requestMatchers("/swagger-ui/**", "/v3/api-docs/**", "/oauth2/**",
                     "/login/oauth2/**").permitAll()

--- a/src/main/java/com/pawpawlog/global/config/SecurityConfig.java
+++ b/src/main/java/com/pawpawlog/global/config/SecurityConfig.java
@@ -8,6 +8,7 @@ import com.pawpawlog.global.jwt.JwtTokenProvider;
 import com.pawpawlog.global.redis.RedisDao;
 import com.pawpawlog.global.security.CustomAccessDeniedHandler;
 import com.pawpawlog.global.security.CustomAuthenticationEntryPoint;
+import com.pawpawlog.global.security.ExceptionHandlingFilter;
 import com.pawpawlog.global.security.LoginAuthenticationProvider;
 import com.pawpawlog.global.security.LoginFilter;
 import lombok.RequiredArgsConstructor;
@@ -24,6 +25,7 @@ import org.springframework.security.config.annotation.web.configurers.AbstractHt
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.security.web.session.DisableEncodeUrlFilter;
 import tools.jackson.databind.ObjectMapper;
 
 @Configuration
@@ -67,6 +69,8 @@ public class SecurityConfig {
     JwtAuthenticationFilter jwtAuthenticationFilter = new JwtAuthenticationFilter(
         jwtTokenProvider, redisDao, objectMapper, WHITE_LIST);
 
+    ExceptionHandlingFilter exceptionHandlingFilter = new ExceptionHandlingFilter(objectMapper);
+
     http
         .csrf(AbstractHttpConfigurer::disable)
         .sessionManagement(session ->
@@ -74,7 +78,7 @@ public class SecurityConfig {
         .authorizeHttpRequests(auth ->
             auth
                 .requestMatchers(HttpMethod.POST, "/auth/login", "/auth/reissue", "/auth/logout",
-                    "/").permitAll()
+                    "/users", "/").permitAll()
                 .requestMatchers(HttpMethod.GET, "/users/usernames/*", "/health").permitAll()
                 .requestMatchers("/swagger-ui/**", "/v3/api-docs/**", "/oauth2/**",
                     "/login/oauth2/**").permitAll()
@@ -88,7 +92,8 @@ public class SecurityConfig {
             .successHandler(oAuth2LoginSuccessHandler)
             .failureUrl(oauth2RedirectUri + "?error=oauth2_failed"))
         .addFilterAt(loginFilter, UsernamePasswordAuthenticationFilter.class)
-        .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
+        .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
+        .addFilterBefore(exceptionHandlingFilter, DisableEncodeUrlFilter.class);
 
     return http.build();
   }

--- a/src/main/java/com/pawpawlog/global/exception/ErrorCode.java
+++ b/src/main/java/com/pawpawlog/global/exception/ErrorCode.java
@@ -16,6 +16,10 @@ public enum ErrorCode {
   PET_LIMIT_EXCEEDED(HttpStatus.BAD_REQUEST, "반려동물은 최대 5마리까지 등록할 수 있습니다."),
   PET_IS_CURRENT(HttpStatus.BAD_REQUEST, "대표 반려동물은 삭제할 수 없습니다. 다른 반려동물을 대표로 지정해주세요."),
 
+  // Diary
+  DIARY_NOT_FOUND(HttpStatus.NOT_FOUND, "다이어리를 찾을 수 없습니다."),
+  DIARY_ALREADY_EXISTS(HttpStatus.CONFLICT, "해당 날짜에 이미 기록이 존재합니다."),
+
   // Auth
   UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "로그인이 필요합니다."),
   FORBIDDEN(HttpStatus.FORBIDDEN, "접근 권한이 없습니다."),

--- a/src/main/java/com/pawpawlog/global/exception/ErrorCode.java
+++ b/src/main/java/com/pawpawlog/global/exception/ErrorCode.java
@@ -35,6 +35,7 @@ public enum ErrorCode {
   // Request
   INVALID_INPUT(HttpStatus.BAD_REQUEST, "입력값이 올바르지 않습니다."),
   NOT_FOUND(HttpStatus.NOT_FOUND, "요청한 리소스를 찾을 수 없습니다."),
+  DATA_CONFLICT(HttpStatus.CONFLICT, "이미 존재하는 데이터입니다."),
 
   // Server
   INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 오류가 발생했습니다.");

--- a/src/main/java/com/pawpawlog/global/exception/ErrorCode.java
+++ b/src/main/java/com/pawpawlog/global/exception/ErrorCode.java
@@ -23,6 +23,9 @@ public enum ErrorCode {
   // Auth
   UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "로그인이 필요합니다."),
   FORBIDDEN(HttpStatus.FORBIDDEN, "접근 권한이 없습니다."),
+  ACCOUNT_SUSPENDED(HttpStatus.UNAUTHORIZED, "정지된 계정입니다."),
+  ACCOUNT_DELETED(HttpStatus.UNAUTHORIZED, "탈퇴한 계정입니다."),
+  OAUTH2_CODE_INVALID(HttpStatus.UNAUTHORIZED, "유효하지 않거나 만료된 인증 코드입니다."),
 
   // Token
   MISSING_TOKEN(HttpStatus.UNAUTHORIZED, "토큰이 존재하지 않습니다."),

--- a/src/main/java/com/pawpawlog/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/pawpawlog/global/exception/GlobalExceptionHandler.java
@@ -5,6 +5,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.validation.FieldError;
@@ -84,6 +85,16 @@ public class GlobalExceptionHandler {
   protected ResponseEntity<ErrorResponse> handleNoResourceFound(NoResourceFoundException e) {
     ErrorCode errorCode = ErrorCode.NOT_FOUND;
     log.warn("존재하지 않는 리소스 요청: {}", e.getMessage());
+    return ResponseEntity
+        .status(errorCode.getStatus())
+        .body(ErrorResponse.error(errorCode.name(), errorCode.getMessage()));
+  }
+
+  @ExceptionHandler(DataIntegrityViolationException.class)
+  protected ResponseEntity<ErrorResponse> handleDataIntegrityViolation(
+      DataIntegrityViolationException e) {
+    ErrorCode errorCode = ErrorCode.DATA_CONFLICT;
+    log.warn("데이터 무결성 제약 위반: {}", e.getMessage());
     return ResponseEntity
         .status(errorCode.getStatus())
         .body(ErrorResponse.error(errorCode.name(), errorCode.getMessage()));

--- a/src/main/java/com/pawpawlog/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/pawpawlog/global/exception/GlobalExceptionHandler.java
@@ -6,12 +6,14 @@ import java.util.Map;
 import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.MissingRequestHeaderException;
-import org.springframework.web.servlet.resource.NoResourceFoundException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+import org.springframework.web.servlet.resource.NoResourceFoundException;
 
 @Slf4j
 @RestControllerAdvice
@@ -20,7 +22,7 @@ public class GlobalExceptionHandler {
   @ExceptionHandler(CustomException.class)
   protected ResponseEntity<ErrorResponse> handleCustomException(CustomException e) {
     ErrorCode errorCode = e.getErrorCode();
-    log.warn("CustomException: {}", errorCode.name());
+    log.warn("커스텀 예외 발생: {}", errorCode.name());
     return ResponseEntity
         .status(errorCode.getStatus())
         .body(ErrorResponse.error(errorCode.name(), errorCode.getMessage()));
@@ -33,6 +35,26 @@ public class GlobalExceptionHandler {
     return ResponseEntity
         .status(errorCode.getStatus())
         .body(ErrorResponse.error(errorCode.name(), e.getMessage()));
+  }
+
+  @ExceptionHandler(MethodArgumentTypeMismatchException.class)
+  protected ResponseEntity<ErrorResponse> handleTypeMismatch(
+      MethodArgumentTypeMismatchException e) {
+    ErrorCode errorCode = ErrorCode.INVALID_INPUT;
+    log.warn("파라미터 타입 불일치: {} = {}", e.getName(), e.getValue());
+    return ResponseEntity
+        .status(errorCode.getStatus())
+        .body(ErrorResponse.error(errorCode.name(), errorCode.getMessage()));
+  }
+
+  @ExceptionHandler(HttpMessageNotReadableException.class)
+  protected ResponseEntity<ErrorResponse> handleMessageNotReadable(
+      HttpMessageNotReadableException e) {
+    ErrorCode errorCode = ErrorCode.INVALID_INPUT;
+    log.warn("요청 본문 파싱 실패: {}", e.getMessage());
+    return ResponseEntity
+        .status(errorCode.getStatus())
+        .body(ErrorResponse.error(errorCode.name(), errorCode.getMessage()));
   }
 
   @ExceptionHandler(MethodArgumentNotValidException.class)
@@ -61,7 +83,7 @@ public class GlobalExceptionHandler {
   @ExceptionHandler(NoResourceFoundException.class)
   protected ResponseEntity<ErrorResponse> handleNoResourceFound(NoResourceFoundException e) {
     ErrorCode errorCode = ErrorCode.NOT_FOUND;
-    log.warn("NoResourceFoundException: {}", e.getMessage());
+    log.warn("존재하지 않는 리소스 요청: {}", e.getMessage());
     return ResponseEntity
         .status(errorCode.getStatus())
         .body(ErrorResponse.error(errorCode.name(), errorCode.getMessage()));
@@ -70,7 +92,7 @@ public class GlobalExceptionHandler {
   @ExceptionHandler(Exception.class)
   protected ResponseEntity<ErrorResponse> handleException(Exception e) {
     ErrorCode errorCode = ErrorCode.INTERNAL_SERVER_ERROR;
-    log.error("Unhandled exception", e);
+    log.error("처리되지 않은 예외 발생", e);
     return ResponseEntity
         .status(errorCode.getStatus())
         .body(ErrorResponse.error(errorCode.name(), errorCode.getMessage()));

--- a/src/main/java/com/pawpawlog/global/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/pawpawlog/global/jwt/JwtTokenProvider.java
@@ -88,10 +88,10 @@ public class JwtTokenProvider {
       Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token);
       return true;
     } catch (ExpiredJwtException e) {
-      log.error("Expired JWT Token");
+      log.error("만료된 JWT 토큰");
       throw new CustomException(ErrorCode.EXPIRED_TOKEN);
     } catch (JwtException | IllegalArgumentException e) {
-      log.error("Invalid JWT Token: {}", e.getMessage());
+      log.error("유효하지 않은 JWT 토큰: {}", e.getMessage());
       throw new CustomException(ErrorCode.INVALID_TOKEN);
     }
   }
@@ -101,7 +101,7 @@ public class JwtTokenProvider {
       Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token);
     } catch (ExpiredJwtException ignored) {
     } catch (JwtException | IllegalArgumentException e) {
-      log.error("Invalid JWT Token on logout: {}", e.getMessage());
+      log.error("로그아웃 시 유효하지 않은 JWT 토큰: {}", e.getMessage());
       throw new CustomException(ErrorCode.INVALID_TOKEN);
     }
   }

--- a/src/main/java/com/pawpawlog/global/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/pawpawlog/global/jwt/JwtTokenProvider.java
@@ -60,7 +60,13 @@ public class JwtTokenProvider {
   }
 
   public JwtToken generateTokenForUserId(String id) {
-    UserDetails userDetails = userDetailsService.loadUserByUsername(id);
+    CustomUserDetails userDetails = (CustomUserDetails) userDetailsService.loadUserByUsername(id);
+    if (!userDetails.isAccountNonLocked()) {
+      throw new CustomException(ErrorCode.ACCOUNT_SUSPENDED);
+    }
+    if (!userDetails.isEnabled()) {
+      throw new CustomException(ErrorCode.ACCOUNT_DELETED);
+    }
     String authorities = extractAuthorities(userDetails.getAuthorities());
     return createTokenPair(id, authorities);
   }

--- a/src/main/java/com/pawpawlog/global/redis/RedisDao.java
+++ b/src/main/java/com/pawpawlog/global/redis/RedisDao.java
@@ -12,6 +12,7 @@ public class RedisDao {
 
   private static final String REFRESH_TOKEN_PREFIX = "refreshToken:";
   private static final String BLACKLIST_PREFIX = "blacklist:";
+  private static final String OAUTH2_CODE_PREFIX = "oauth2Code:";
 
   private final RedisTemplate<String, Object> redisTemplate;
 
@@ -38,5 +39,19 @@ public class RedisDao {
   public boolean isBlacklisted(String accessToken) {
     String tokenHash = DigestUtils.md5DigestAsHex(accessToken.getBytes());
     return Boolean.TRUE.equals(redisTemplate.hasKey(BLACKLIST_PREFIX + tokenHash));
+  }
+
+  public void saveOAuth2Code(String code, String userId, long expirationMillis) {
+    redisTemplate.opsForValue()
+        .set(OAUTH2_CODE_PREFIX + code, userId, expirationMillis, TimeUnit.MILLISECONDS);
+  }
+
+  public String getUserIdByOAuth2Code(String code) {
+    Object value = redisTemplate.opsForValue().get(OAUTH2_CODE_PREFIX + code);
+    return value != null ? value.toString() : null;
+  }
+
+  public void deleteOAuth2Code(String code) {
+    redisTemplate.delete(OAUTH2_CODE_PREFIX + code);
   }
 }

--- a/src/main/java/com/pawpawlog/global/security/ExceptionHandlingFilter.java
+++ b/src/main/java/com/pawpawlog/global/security/ExceptionHandlingFilter.java
@@ -1,0 +1,43 @@
+package com.pawpawlog.global.security;
+
+import com.pawpawlog.global.exception.CustomException;
+import com.pawpawlog.global.exception.ErrorCode;
+import com.pawpawlog.global.util.HttpResponseUtil;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.filter.OncePerRequestFilter;
+import tools.jackson.databind.ObjectMapper;
+
+@Slf4j
+@RequiredArgsConstructor
+public class ExceptionHandlingFilter extends OncePerRequestFilter {
+
+  private final ObjectMapper objectMapper;
+
+  @Override
+  protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
+      FilterChain filterChain) throws ServletException, IOException {
+    try {
+      filterChain.doFilter(request, response);
+    } catch (CustomException e) {
+      log.warn("필터 체인 커스텀 예외 발생: {}", e.getErrorCode().name());
+      writeError(response, e.getErrorCode());
+    } catch (Exception e) {
+      log.error("필터 체인 처리되지 않은 예외 발생", e);
+      writeError(response, ErrorCode.INTERNAL_SERVER_ERROR);
+    }
+  }
+
+  private void writeError(HttpServletResponse response, ErrorCode errorCode) throws IOException {
+    if (response.isCommitted()) {
+      log.warn("응답이 이미 커밋되어 에러 응답을 쓸 수 없음: {}", errorCode.name());
+      return;
+    }
+    HttpResponseUtil.writeErrorResponse(response, errorCode, objectMapper);
+  }
+}

--- a/src/main/java/com/pawpawlog/global/security/LoginFilter.java
+++ b/src/main/java/com/pawpawlog/global/security/LoginFilter.java
@@ -13,6 +13,8 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.AuthenticationServiceException;
+import org.springframework.security.authentication.DisabledException;
+import org.springframework.security.authentication.LockedException;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.AuthenticationException;
@@ -76,6 +78,19 @@ public class LoginFilter extends UsernamePasswordAuthenticationFilter {
       HttpServletResponse response,
       AuthenticationException failed) throws IOException {
     log.warn("로그인 실패: {}", failed.getMessage());
-    HttpResponseUtil.writeErrorResponse(response, ErrorCode.UNAUTHORIZED, objectMapper);
+    HttpResponseUtil.writeErrorResponse(response, resolveErrorCode(failed), objectMapper);
+  }
+
+  private ErrorCode resolveErrorCode(AuthenticationException failed) {
+    if (failed instanceof AuthenticationServiceException) {
+      return ErrorCode.INVALID_INPUT;
+    }
+    if (failed instanceof LockedException) {
+      return ErrorCode.ACCOUNT_SUSPENDED;
+    }
+    if (failed instanceof DisabledException) {
+      return ErrorCode.ACCOUNT_DELETED;
+    }
+    return ErrorCode.UNAUTHORIZED;
   }
 }

--- a/src/main/java/com/pawpawlog/pet/dto/request/PetUpdateRequest.java
+++ b/src/main/java/com/pawpawlog/pet/dto/request/PetUpdateRequest.java
@@ -1,14 +1,18 @@
 package com.pawpawlog.pet.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.PastOrPresent;
+import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 import java.time.LocalDate;
 
 public record PetUpdateRequest(
-    @Size(min = 1, max = 50)
+    @Size(max = 50)
+    @Pattern(regexp = "(?s).*\\S.*", message = "공백일 수 없습니다.")
     @Schema(description = "반려동물 이름 (최대 50자)", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
     String name,
 
+    @PastOrPresent
     @Schema(description = "반려동물 생일", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
     LocalDate birthDate
 ) {

--- a/src/main/java/com/pawpawlog/pet/entity/Pet.java
+++ b/src/main/java/com/pawpawlog/pet/entity/Pet.java
@@ -1,7 +1,9 @@
 package com.pawpawlog.pet.entity;
 
+import com.pawpawlog.diary.entity.Diary;
 import com.pawpawlog.global.domain.BaseEntity;
 import com.pawpawlog.user.entity.User;
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -12,8 +14,11 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -48,6 +53,10 @@ public class Pet extends BaseEntity {
   @Column(nullable = false)
   @Builder.Default
   private boolean isCurrent = false;
+
+  @OneToMany(mappedBy = "pet", cascade = CascadeType.REMOVE, orphanRemoval = true)
+  @Builder.Default
+  private List<Diary> diaries = new ArrayList<>();
 
   public void updateName(String name) {
     this.name = name;

--- a/src/main/java/com/pawpawlog/pet/service/PetService.java
+++ b/src/main/java/com/pawpawlog/pet/service/PetService.java
@@ -26,7 +26,7 @@ public class PetService {
 
   @Transactional
   public PetResponse register(Long userId, PetCreateRequest request) {
-    User user = getUser(userId);
+    User user = getUserForUpdate(userId);
     long count = petRepository.countByUser(user);
     if (count >= MAX_PET_COUNT) {
       throw new CustomException(ErrorCode.PET_LIMIT_EXCEEDED);
@@ -48,7 +48,7 @@ public class PetService {
 
   @Transactional
   public PetResponse designateCurrent(Long userId, Long petId) {
-    User user = getUser(userId);
+    User user = getUserForUpdate(userId);
     Pet target = petRepository.findByIdAndUser(petId, user)
         .orElseThrow(() -> new CustomException(ErrorCode.PET_NOT_FOUND));
     petRepository.findAllByUser(user).stream()
@@ -85,6 +85,11 @@ public class PetService {
 
   private User getUser(Long userId) {
     return userRepository.findById(userId)
+        .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+  }
+
+  private User getUserForUpdate(Long userId) {
+    return userRepository.findByIdForUpdate(userId)
         .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
   }
 }

--- a/src/main/java/com/pawpawlog/user/repository/UserRepository.java
+++ b/src/main/java/com/pawpawlog/user/repository/UserRepository.java
@@ -2,8 +2,12 @@ package com.pawpawlog.user.repository;
 
 import com.pawpawlog.user.entity.Provider;
 import com.pawpawlog.user.entity.User;
+import jakarta.persistence.LockModeType;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface UserRepository extends JpaRepository<User, Long> {
 
@@ -12,4 +16,8 @@ public interface UserRepository extends JpaRepository<User, Long> {
   boolean existsByUsername(String username);
 
   Optional<User> findByProviderAndProviderId(Provider provider, String providerId);
+
+  @Lock(LockModeType.PESSIMISTIC_WRITE)
+  @Query("select u from User u where u.id = :id")
+  Optional<User> findByIdForUpdate(@Param("id") Long id);
 }

--- a/src/main/java/com/pawpawlog/user/service/UserService.java
+++ b/src/main/java/com/pawpawlog/user/service/UserService.java
@@ -10,6 +10,7 @@ import com.pawpawlog.user.entity.User;
 import com.pawpawlog.user.repository.UserRepository;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -42,7 +43,11 @@ public class UserService {
         .nickname(request.nickname())
         .build();
 
-    return UserResponse.from(userRepository.save(user));
+    try {
+      return UserResponse.from(userRepository.save(user));
+    } catch (DataIntegrityViolationException e) {
+      throw new CustomException(ErrorCode.DUPLICATE_USERNAME);
+    }
   }
 
   @Transactional

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -79,3 +79,4 @@ jwt:
 app:
   oauth2:
     redirect-uri: ${OAUTH2_REDIRECT_URI}
+    code-expiration: ${OAUTH2_CODE_EXPIRATION:60000}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -20,6 +20,8 @@ spring:
 
   jackson:
     time-zone: Asia/Seoul
+    deserialization:
+      fail-on-unknown-properties: true
 
   data:
     redis:


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- #27 

## 📝 작업 내용

- 반려동물 다이어리 등록 / 조회 / 수정 / 삭제 API 구현
- 필터 체인 예외 처리 및 요청 값 타입 검증 강화
- 회원가입(`POST /users`) 화이트리스트 누락 수정
- Java 21 업그레이드 및 devtools 의존성 추가